### PR TITLE
Dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ set(CURSES_NEED_NCURSES TRUE)
 include(FindCurses)
 target_link_libraries(bngblaster ${CURSES_LIBRARIES} crypto jansson ${libdict} m)
 
-SET(PLATFORM_SPECIFIC_LIBS "-lpthread")
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+set(PLATFORM_SPECIFIC_LIBS "-lpthread")
+string(APPEND CMAKE_C_FLAGS "-pthread")
 
 
 # add experimental netmap support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ if(BNGBLASTER_TESTS)
 endif()
 
 install(TARGETS bngblaster DESTINATION sbin)
+install(PROGRAMS bngblaster-cli DESTINATION sbin)
 
 set(CPACK_GENERATOR "DEB")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libssl1.1, libncurses5, libjansson4")

--- a/bngblaster-cli
+++ b/bngblaster-cli
@@ -16,9 +16,18 @@ import os
 import json
 import ast
 
+
+def error(*args, **kwargs):
+    """print error and exit"""
+    print(*args, file=sys.stderr, **kwargs)
+    sys.exit(1)
+
+
 def usage():
-    print("""
-BNG Blaster Control Socket Client
+    error("""BNG Blaster CLI Tool
+
+The CLI tool is a simple control socket client
+for interactive communication with the BNG Blaster.
 
 {c} <socket> <command> [arguments]
 
@@ -27,13 +36,7 @@ Examples:
     {c} run.sock igmp-join session-id 1 group 239.0.0.1 source1 1.1.1.1 source2 2.2.2.2 source3 3.3.3.3
     {c} run.sock igmp-info session-id 1
     {c} run.sock l2tp-csurq tunnel-id 1 sessions [1,2]
-
 """.format(c=sys.argv[0]))
-    sys.exit(1)
-
-def error(*args, **kwargs):
-    """print error and exit"""
-    print(*args, file=sys.stderr, **kwargs)
     sys.exit(1)
 
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -139,6 +139,26 @@ Therefore the interface MTU should be increased using the following commands.
 sudo ip link set mtu 9000 dev <interface>
 ```
 
+This can be also archived via netplan using the following configuration for each BNG Blaster
+interface. 
+
+```yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth1:
+      dhcp4: no
+      dhcp6: no
+      link-local: []
+      mtu: 9000
+    eth2:
+      dhcp4: no
+      dhcp6: no
+      link-local: []
+      mtu: 9000
+```
+
 ### Network Interface
 
 `"interfaces": { "network": { ... } }`

--- a/docs/ctrl.md
+++ b/docs/ctrl.md
@@ -2,8 +2,8 @@
 
 The control socket is an unix domain stream socket which allows the control daemon to
 interact with the BNG Blaster using JSON RPC. This interface was primary developed for
-then BNG Blaster Controller but can be also used manually or by other tools like the
-simple CLI tool (`cli.py`) for interactive communication with the BNG Blaster.
+the BNG Blaster Controller but can be also used manually or by other tools like the
+simple CLI tool `bngblaster-cli` for interactive communication with the BNG Blaster.
 
 The control socket will be optionally enabled by providing the path to the socket file
 using the argument `-S` (`bngblaster -S test.socket`).
@@ -118,6 +118,37 @@ if request was successfully. The status can be also set to `warning` or
 }
 ```
 
+## BNG Blaster CLI
+
+The python script `bngblaster-cli` provides a simple CLI tool
+for interactive communication with the BNG Blaster.
+
+```
+$ sudo bngblaster-cli 
+BNG Blaster Control Socket Client
+
+bngblaster-cli <socket> <command> [arguments]
+
+Examples:
+    bngblaster-cli run.sock session-info session-id 1
+    bngblaster-cli run.sock igmp-join session-id 1 group 239.0.0.1 source1 1.1.1.1 source2 2.2.2.2 source3 3.3.3.3
+    bngblaster-cli run.sock igmp-info session-id 1
+    bngblaster-cli run.sock l2tp-csurq tunnel-id 1 sessions [1,2]
+```
+
+`$ sudo bngblaster-cli run.sock session-counters | jq .`
+```json
+{
+  "status": "ok",
+  "code": 200,
+  "session-counters": {
+    "sessions": 1,
+    "sessions-established": 1,
+    "sessions-flapped": 0,
+    "dhcpv6-sessions-established": 1
+  }
+}
+```
 ## Control Socket Commands
 
 ### Global Commands
@@ -218,4 +249,4 @@ session-id for which a connect speed update is requested.
 
 This command can be executed as shown below using the CLI tool.
 
-`$ sudo ./cli.py run.sock l2tp-csurq tunnel-id 1 sessions [1,2,3,4]`
+`$ sudo bngblaster-cli run.sock l2tp-csurq tunnel-id 1 sessions [1,2,3,4]`

--- a/docs/ctrl.md
+++ b/docs/ctrl.md
@@ -124,7 +124,7 @@ The python script `bngblaster-cli` provides a simple CLI tool
 for interactive communication with the BNG Blaster.
 
 ```
-$ sudo bngblaster-cli 
+$ sudo bngblaster-cli
 BNG Blaster Control Socket Client
 
 bngblaster-cli <socket> <command> [arguments]
@@ -159,10 +159,10 @@ Attribute | Description
 `session-counters` | Return session counters
 `terminate` | Terminate all sessions similar to sending SIGINT (ctr+c)
 `session-traffic` | Display session traffic statistics
-`session-traffic-enabled` | Enable session traffic for all sessions
-`session-traffic-disabled` | Disable session traffic for all sessions
-`stream-traffic-enabled` | Enable stream traffic for all sessions
-`stream-traffic-disabled` | Disable stream traffic for all sessions
+`session-traffic-start` (Alias: `session-traffic-enabled`) | Start sending session traffic for all sessions
+`session-traffic-stop` (Alias: `session-traffic-disabled`) | Stop sending session traffic for all sessions
+`stream-traffic-start` (Alias: `stream-traffic-enabled`)  | Start sending stream traffic for all sessions
+`stream-traffic-stop` (Alias: `stream-traffic-disabled`) | Stop sending stream traffic for all sessions
 `multicast-traffic-start` | Start sending multicast traffic from network interface
 `multicast-traffic-stop` | Stop sending multicast traffic from network interface
 `li-flows` | List all LI flows with detailed statistics
@@ -201,11 +201,11 @@ Attribute | Description | Mandatory Arguments | Optional Arguments
 `ipcp-close` | Close IPCP | |
 `ip6cp-open`| Open IP6CP | |
 `ip6cp-close` | Close IP6CP | |
-`session-traffic-enabled` | Enable session traffic | |
-`session-traffic-disabled` | Disable session traffic | |
+`session-traffic-start` (Alias: `session-traffic-enabled`) | Enable session traffic | |
+`session-traffic-stop` (Alias: `session-traffic-disabled`) | Disable session traffic | |
 `session-streams` | Session traffic stream information | |
-`stream-traffic-enabled` | Enable session stream traffic | |
-`stream-traffic-disabled` | Disable session stream traffic | |
+`stream-traffic-start` (Alias: `stream-traffic-enabled`) | Enable session stream traffic | |
+`stream-traffic-stop` (Alias: `stream-traffic-disabled`) | Disable session stream traffic | |
 `igmp-join` | Join group | `group` | `source1`, `source2`, `source3`
 `igmp-leave` | Leave group | `group` |
 `igmp-info` | IGMP information | |

--- a/docs/ctrl.md
+++ b/docs/ctrl.md
@@ -46,7 +46,7 @@ the actual command which is invoked with optional arguments.
 {
     "status": "ok",
     "code": 200,
-    "session-information": {
+    "session-info": {
         "type": "pppoe",
         "session-id": 1,
         "session-state": "Established",

--- a/docs/ctrl.md
+++ b/docs/ctrl.md
@@ -227,6 +227,8 @@ Attribute | Description | Mandatory Arguments | Optional Arguments
 `l2tp-tunnels` | L2TP tunnel information | |
 `l2tp-sessions` | L2TP session information | | `tunnel-id`, `session-id`
 `l2tp-csurq`| Send L2TP CSURQ | `tunnel-id` | `sessions`
+`l2tp-tunnel-terminate` | Terminate L2TP tunnel | `tunnel-id` | `result-code`, `error-code`, `error-message`
+`l2tp-session-terminate` | Terminate L2TP session | `session-id` | `result-code`, `error-code`, `error-message`, `disconnect-code`, `disconnect-protocol`, ``disconnect-direction`, `disconnect-message`
 
 The L2TP CSURQ command expects the local tunnel-id and a list of remote
 session-id for which a connect speed update is requested.
@@ -250,3 +252,7 @@ session-id for which a connect speed update is requested.
 This command can be executed as shown below using the CLI tool.
 
 `$ sudo bngblaster-cli run.sock l2tp-csurq tunnel-id 1 sessions [1,2,3,4]`
+
+The L2TP session terminate command allows to test result (RFC2661) and disconnect (RFC3145) codes. 
+
+`$ sudo bngblaster-cli run.sock l2tp-session-terminate session-id 1 result-code 2 error-message "LCP request" disconnect-code 3 disconnect-message "LCP terminate request"`

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,27 +3,29 @@
 ## Install Ubuntu
 
 Install dependencies:
-```
+
+```cli
 sudo apt install -y libssl1.1 libncurses5 libjansson4
 ```
 
 Download and install debian package:
-https://github.com/rtbrick/bngblaster/releases
+[https://github.com/rtbrick/bngblaster/releases](https://github.com/rtbrick/bngblaster/releases)
 
-```
+```cli
 sudo dpkg -i <package>
 ```
 
-This command installs the BNG Blaster to `/usr/sbin/bngblaster`. 
+This command installs the BNG Blaster to `/usr/sbin/bngblaster`.
 
 ## Build from Sources
 
 ### Dependencies
 
-The BNG Blaster has dependencies to the RtBrick libdict fork
-(https://github.com/rtbrick/libdict) and the following standard
+The BNG Blaster has dependencies to the RtBrick [libdict
+fork](https://github.com/rtbrick/libdict) and the following standard
 dependencies:
-```
+
+```cli
 sudo apt install -y cmake \
     libcunit1-dev \
     libncurses5-dev \
@@ -35,7 +37,8 @@ sudo apt install -y cmake \
 
 Per default cmake (`cmake .`) will build the BNG Blaster as release
 version with optimization and without debug symbols.
-```
+
+```cli
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
@@ -44,7 +47,8 @@ make all
 
 Alternative it is also possible to build a debug
 version for detailed troubleshooting using gdb.
-```
+
+```cli
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Debug ..
@@ -56,12 +60,14 @@ package by just executing `cpack` from build directory.
 
 It is also recommended to provide the GIT commit details to be included in the
 manually build version as shown below:
-```
-cmake -DGIT_REF=`git rev-parse --abbrev-ref HEAD` -DGIT_SHA=`git rev-parse HEAD` ..
+
+```cli
+cmake -DGIT_REF=`git rev-parse --abbrev-ref HEAD` -DGIT_SHA=`git rev-parse HEAD` .
 ```
 
 *Example:*
-```
+
+```cli
 $ bngblaster -v
 GIT:
   REF: dev
@@ -72,36 +78,41 @@ IO Modes: packet_mmap_raw (default), packet_mmap, raw
 ### Install
 
 Then BNG Blaster can be installed using make install target.
-```
+
+```cli
 sudo make install
 ```
 
-This command installs the BNG Blaster to `/usr/local/sbin/bngblaster`. 
+This command installs the BNG Blaster to `/usr/local/sbin/bngblaster`.
 
-An existing version installed from debian package in `/usr/sbin` is 
+An existing version installed from debian package in `/usr/sbin` is
 not automatically replaced or removed here and should be deleted manually
 before install. Otherwise it might be possible that two versions remain
-in parallel. 
-```
+in parallel.
+
+```cli
 sudo rm /usr/sbin/bngblaster
 ```
 
 ### Build and Run Unit Tests
 
 Building and running unit tests requires CMocka to be installed:
-```
+
+```cli
 sudo apt install libcmocka-dev
 ```
 
 The option `BNGBLASTER_TESTS` enables to build unit tests.
-```
+
+```cli
 cmake -DCMAKE_BUILD_TYPE=Debug -DBNGBLASTER_TESTS=ON .
 make all
 make test
 ```
 
-*Example*
-```
+*Example:*
+
+```cli
 $ make test
 Running tests...
 Test project
@@ -111,4 +122,27 @@ Test project
 100% tests passed, 0 tests failed out of 1
 
 Total Test time (real) =   0.00 sec
+```
+
+### Running bngblaster
+
+bngblaster needs permissions to send raw packets and change network interface
+settings. The easiest way to run bngblaster is either as the root user or with
+sudo:
+
+```cli
+# As root
+bngblaster -C config.json -I
+
+# As a normal user:
+sudo bngblaster -C config.json -I
+```
+
+A third option is to set capabilities on the binary with e.g. `setcap`:
+
+```cli
+sudo setcap cap_net_raw,cap_net_admin,cap_dac_read_search+eip /path/to/bngblaster
+
+# As either root or a normal user:
+bngblaster -C config.json -I
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -124,10 +124,10 @@ Test project
 Total Test time (real) =   0.00 sec
 ```
 
-### Running bngblaster
+### Running BNG Blaster
 
-bngblaster needs permissions to send raw packets and change network interface
-settings. The easiest way to run bngblaster is either as the root user or with
+The BNG Blaster needs permissions to send raw packets and change network interface
+settings. The easiest way to run the BNG Blaster is either as the root user or with
 sudo:
 
 ```cli
@@ -138,11 +138,12 @@ bngblaster -C config.json -I
 sudo bngblaster -C config.json -I
 ```
 
-A third option is to set capabilities on the binary with e.g. `setcap`:
+A third option is to set capabilities on the binary with in example `setcap`
+as shown below:
 
 ```cli
-sudo setcap cap_net_raw,cap_net_admin,cap_dac_read_search+eip /path/to/bngblaster
+sudo setcap cap_net_raw,cap_net_admin,cap_dac_read_search+eip `which bngblaster`
 
-# As either root or a normal user:
+# As normal user:
 bngblaster -C config.json -I
 ```

--- a/docs/ipoe.md
+++ b/docs/ipoe.md
@@ -61,7 +61,7 @@ The most common case for IPoE is using DHCPv4/v6 as shown below.
 The control socket command `session-info session-id <id>` provides
 detailed information for IPOE sessions. 
 
-`$ sudo bngblaster-cli run.sock session-info session-id 1`
+`$ sudo bngblaster-cli run.sock session-info session-id 1 | jq .`
 ```json
 {
     "status": "ok",
@@ -70,7 +70,7 @@ detailed information for IPOE sessions.
         "type": "ipoe",
         "session-id": 1,
         "session-state": "Established",
-        "interface": "veth1",
+        "interface": "eth1",
         "outer-vlan": 8,
         "inner-vlan": 1,
         "mac": "02:00:00:00:00:01",

--- a/docs/ipoe.md
+++ b/docs/ipoe.md
@@ -61,7 +61,7 @@ The most common case for IPoE is using DHCPv4/v6 as shown below.
 The control socket command `session-info session-id <id>` provides
 detailed information for IPOE sessions. 
 
-`$ sudo ./cli.py run.sock session-info session-id 1`
+`$ sudo bngblaster-cli run.sock session-info session-id 1`
 ```json
 {
     "status": "ok",

--- a/docs/l2tp.md
+++ b/docs/l2tp.md
@@ -4,8 +4,6 @@ The BNG Blaster is able to emulate L2TPv2 (RFC2661) LNS servers to
 be able to test the L2TPv2 LAC functionality of the BNG device under
 test.
 
-## Configuration
-
 Following an example with 30 L2TP LNS servers.
 
 ```json

--- a/docs/l2tp.md
+++ b/docs/l2tp.md
@@ -260,7 +260,7 @@ Following an example with 30 L2TP LNS servers.
 
 ## Receive Tunnel Information
 
-`$ sudo ./cli.py run.sock l2tp-tunnels`
+`$ sudo bngblaster-cli run.sock l2tp-tunnels`
 ```json
 {
     "status": "ok",
@@ -292,7 +292,7 @@ Following an example with 30 L2TP LNS servers.
 
 The `l2tp-sessions` command returns all L2TP sessions.
 
-`$ sudo ./cli.py run.sock l2tp-sessions`
+`$ sudo bngblaster-cli run.sock l2tp-sessions`
 ```json
 {
     "status": "ok",
@@ -324,11 +324,11 @@ The `l2tp-sessions` command returns all L2TP sessions.
 This output can be also filtered to return only sessions
 of a given tunnel.
 
-`sudo ./cli.py run.sock l2tp-sessions tunnel-id 1`
+`sudo bngblaster-cli run.sock l2tp-sessions tunnel-id 1`
 
 It is also possible to display a single session.
 
-`$ sudo ./cli.py run.sock l2tp-sessions tunnel-id 1 session-id 1`
+`$ sudo bngblaster-cli run.sock l2tp-sessions tunnel-id 1 session-id 1`
 
 ## RFC5515
 

--- a/docs/li.md
+++ b/docs/li.md
@@ -32,7 +32,7 @@ mediation device as shown in the following example.
 
 The received flows can be queried using the control socket.
 
-`$ sudo ./cli.py run.sock li-flows`
+`$ sudo bngblaster-cli run.sock li-flows`
 ```json
 {
     "status": "ok",

--- a/docs/multicast.md
+++ b/docs/multicast.md
@@ -53,14 +53,14 @@ precise IGMP join/leave delay measurements.
 It is possible to join and leave multicast groups manually using the <<Control Socket>> as
 shown in the example below.
 
-`$ sudo ./cli.py run.sock igmp-join session-id 1 group 232.1.1.1 source1 202.11.23.101 source2 202.11.23.102 source3 202.11.23.103`
+`$ sudo bngblaster-cli run.sock igmp-join session-id 1 group 232.1.1.1 source1 202.11.23.101 source2 202.11.23.102 source3 202.11.23.103`
 ```json
 {
     "status": "ok"
 }
 ```
 
-`$ sudo ./cli.py run.sock igmp-info session-id 1`
+`$ sudo bngblaster-cli run.sock igmp-info session-id 1`
 ```json
 {
     "status": "ok",
@@ -81,14 +81,14 @@ shown in the example below.
 }
 ```
 
-`$ sudo ./cli.py run.sock igmp-leave session-id 1 group 232.1.1.1 `
+`$ sudo bngblaster-cli run.sock igmp-leave session-id 1 group 232.1.1.1 `
 ```json
 {
     "status": "ok"
 }
 ```
 
-`$ sudo ./cli.py run.sock igmp-info session-id 1`
+`$ sudo bngblaster-cli run.sock igmp-info session-id 1`
 ```json
 {
     "status": "ok",

--- a/docs/pppoe.md
+++ b/docs/pppoe.md
@@ -1,5 +1,164 @@
 # PPPoE
 
-Emulating PPP over Ethernet (PPPoE) sessions was the main
+Emulating PPP over Ethernet (PPPoE) sessions was initial
 use case of the BNG Blaster supporting 1:1 and N:1 VLAN
 mode.
+
+Following a basic PPPoE configuration example which is 
+detailed explained in the configuration section.
+
+```json
+{
+    "interfaces": {
+        "network": {
+            "interface": "eth2",
+            "address": "10.0.0.1",
+            "gateway": "10.0.0.2",
+            "address-ipv6": "fc66:1337:7331::1",
+            "gateway-ipv6": "fc66:1337:7331::2"
+        },
+        "access": [
+            {
+                "interface": "eth1",
+                "type": "pppoe",
+                "outer-vlan-min": 1000,
+                "outer-vlan-max": 1999,
+                "inner-vlan-min": 1,
+                "inner-vlan-max": 4049,
+                "authentication-protocol": "PAP"
+            },
+            {
+                "interface": "eth1",
+                "type": "pppoe",
+                "outer-vlan-min": 2000,
+                "outer-vlan-max": 2999,
+                "inner-vlan-min": 1,
+                "inner-vlan-max": 4049,
+                "authentication-protocol": "CHAP"
+            }
+        ]
+    },
+    "sessions": {
+        "count": 1000,
+        "session-time": 0,
+        "max-outstanding": 800,
+        "start-rate": 400,
+        "stop-rate": 400
+    },
+    "pppoe": {
+        "reconnect": true,
+        "discovery-timeout": 3,
+        "discovery-retry": 10
+    },
+    "ppp": {
+        "mru": 1492,
+        "authentication": {
+            "username": "user{session-global}@rtbrick.com",
+            "password": "test",
+            "timeout": 5,
+            "retry": 30
+        },
+        "lcp": {
+            "conf-request-timeout": 1,
+            "conf-request-retry": 10,
+            "keepalive-interval": 30,
+            "keepalive-retry": 3
+        },
+        "ipcp": {
+            "enable": true,
+            "request-ip": true,
+            "request-dns1": true,
+            "request-dns2": true,
+            "conf-request-timeout": 1,
+            "conf-request-retry": 10
+        },
+        "ip6cp": {
+            "enable": true,
+            "conf-request-timeout": 1,
+            "conf-request-retry": 10
+        }
+    },
+    "dhcpv6": {
+        "enable": true,
+        "rapid-commit": true
+    },
+    "access-line": {
+        "agent-remote-id": "DEU.RTBRICK.{session-global}",
+        "agent-circuit-id": "0.0.0.0/0.0.0.0 eth 0:{session-global}",
+        "rate-up": 1024,
+        "rate-down": 16384
+    },
+    "session-traffic": {
+        "ipv4-pps": 1,
+        "ipv6-pps": 1,
+        "ipv6pd-pps": 1
+    }
+}
+```
+
+The control socket command `session-info session-id <id>` provides
+detailed information for IPOE sessions. 
+
+`$ sudo bngblaster-cli run.sock session-info session-id 1 | jq .`
+```json
+{
+    "status": "ok",
+    "code": 200,
+    "session-information": {
+        "type": "pppoe",
+        "session-id": 1,
+        "session-state": "Established",
+        "interface": "eth1",
+        "outer-vlan": 1000,
+        "inner-vlan": 1,
+        "mac": "02:00:00:00:00:01",
+        "username": "user1@rtbrick.com",
+        "agent-circuit-id": "0.0.0.0/0.0.0.0 eth 0:1",
+        "agent-remote-id": "DEU.RTBRICK.1",
+        "lcp-state": "Opened",
+        "ipcp-state": "Opened",
+        "ip6cp-state": "Opened",
+        "ipv4-address": "10.100.128.0",
+        "ipv4-dns1": "10.0.0.3",
+        "ipv4-dns2": "10.0.0.4",
+        "ipv6-prefix": "fc66:1000:1::/64",
+        "ipv6-delegated-prefix": "fc66:2000::/56",
+        "ipv6-dns1": "fc66::3",
+        "ipv6-dns2": "fc66::4",
+        "dhcpv6-state": "Bound",
+        "dhcpv6-dns1": "fc66::3",
+        "dhcpv6-dns2": "fc66::4",
+        "tx-packets": 10036,
+        "rx-packets": 10083,
+        "rx-fragmented-packets": 0,
+        "session-traffic": {
+            "total-flows": 6,
+            "verified-flows": 6,
+            "first-seq-rx-access-ipv4": 2,
+            "first-seq-rx-access-ipv6": 3,
+            "first-seq-rx-access-ipv6pd": 3,
+            "first-seq-rx-network-ipv4": 2,
+            "first-seq-rx-network-ipv6": 3,
+            "first-seq-rx-network-ipv6pd": 3,
+            "access-tx-session-packets": 3266,
+            "access-rx-session-packets": 3265,
+            "access-rx-session-packets-loss": 0,
+            "network-tx-session-packets": 3266,
+            "network-rx-session-packets": 3265,
+            "network-rx-session-packets-loss": 0,
+            "access-tx-session-packets-ipv6": 3266,
+            "access-rx-session-packets-ipv6": 3264,
+            "access-rx-session-packets-ipv6-loss": 0,
+            "network-tx-session-packets-ipv6": 3266,
+            "network-rx-session-packets-ipv6": 3264,
+            "network-rx-session-packets-ipv6-loss": 0,
+            "access-tx-session-packets-ipv6pd": 3266,
+            "access-rx-session-packets-ipv6pd": 3264,
+            "access-rx-session-packets-ipv6pd-loss": 0,
+            "network-tx-session-packets-ipv6pd": 3266,
+            "network-rx-session-packets-ipv6pd": 3264,
+            "network-rx-session-packets-ipv6pd-loss": 0
+        }
+    }
+}
+```

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -110,7 +110,7 @@ Following a simple example using streams as described in
 
 The `session-streams` command returns detailed stream statistics per session.
 
-`$ sudo ./cli.py run.sock session-streams session-id 1`
+`$ sudo bngblaster-cli run.sock session-streams session-id 1`
 ```json
 {
     "status": "ok",
@@ -229,7 +229,7 @@ accounting of the BNG, meaning session rx/tx packets excluding control traffic.
 
 Each flow can be queried separately using jsonpath expression with name and direction or flow-id.
 
-`$ sudo ./cli.py run.sock session-streams session-id 1 | jq '."session-streams".streams[] | select(.name == "BE" and .direction == "downstream" )'`
+`$ sudo bngblaster-cli run.sock session-streams session-id 1 | jq '."session-streams".streams[] | select(.name == "BE" and .direction == "downstream" )'`
 ```json
 {
   "name": "BE",
@@ -301,10 +301,10 @@ can be also more. With threaded streams we are also able to scale up to three mi
 Session stream traffic can be started/stopped dynamically
 using the commands `stream-traffic-enabled` and `stream-traffic-disabled`.
 
-`$ sudo ./cli.py run.sock stream-traffic-disabled session-id 1`
+`$ sudo bngblaster-cli run.sock stream-traffic-disabled session-id 1`
 
 Those commands start/stop the traffic for all sessions if invoked without
 session identifier.
 
-`$ sudo ./cli.py run.sock stream-traffic-disabled`
+`$ sudo bngblaster-cli run.sock stream-traffic-disabled`
 

--- a/flake.nix
+++ b/flake.nix
@@ -37,14 +37,14 @@
             nativeBuildInputs = buildTools;
 
           };
-          bngblaster = pkgs.stdenv.mkDerivation {
+          bngblaster = pkgs.stdenv.mkDerivation rec {
             pname = "bngblaster";
             version = "0.52";
             src = lib.cleanSource ./.;
 
             doCheck = true;
-            cmakeFlags =
-              [ "-DCMAKE_BUILD_TYPE=Release" "-DBNGBLASTER_TESTS=ON" ];
+            cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ]
+              ++ (if doCheck then [ "-DBNGBLASTER_TESTS=ON" ] else [ ]);
 
             checkInputs = [ pkgs.cmocka pkgs.libpcap ];
             nativeBuildInputs = buildTools;

--- a/src/bbl.c
+++ b/src/bbl.c
@@ -301,7 +301,7 @@ bbl_add_interface (bbl_ctx_s *ctx, char *interface_name)
      * Timer to compute periodic rates.
      */
     timer_add_periodic(&ctx->timer_root, &interface->rate_job, "Rate Computation", 1, 0, interface,
-		               &bbl_compute_interface_rate_job);
+                       &bbl_compute_interface_rate_job);
 
     return interface;
 }
@@ -606,10 +606,10 @@ main (int argc, char *argv[])
                 bbl_print_usage();
                 exit(0);
             case 'P':
-		        ctx->pcap.filename = optarg;
+                ctx->pcap.filename = optarg;
                 break;
             case 'J':
-		        ctx->config.json_report_filename = optarg;
+                ctx->config.json_report_filename = optarg;
                 break;
             case 'C':
                 config_file = optarg;
@@ -618,7 +618,7 @@ main (int argc, char *argv[])
                 log_enable(optarg);
                 break;
             case 'L':
-		        g_log_file = optarg;
+                g_log_file = optarg;
                 break;
             case 'u':
                 username = optarg;
@@ -645,19 +645,15 @@ main (int argc, char *argv[])
                 interactive = true;
                 break;
             case 'S':
-		        ctx->ctrl_socket_path = optarg;
+                ctx->ctrl_socket_path = optarg;
                 break;
             case 'f':
-		        ctx->config.interface_lock_force = true;
+                ctx->config.interface_lock_force = true;
                 break;
             default:
                 bbl_print_usage();
                 exit(1);
         }
-    }
-    if (geteuid() != 0) {
-        fprintf(stderr, "Error: Must be run with root privileges\n");
-	    exit(1);
     }
 
     if(!config_file) {

--- a/src/bbl_config.c
+++ b/src/bbl_config.c
@@ -432,29 +432,33 @@ json_parse_access_interface (bbl_ctx_s *ctx, json_t *access_interface, bbl_acces
     } else {
         access_config->ip6cp_enable = ctx->config.ip6cp_enable;
     }
-    value = json_object_get(access_interface, "ipv4");
-    if (json_is_boolean(value)) {
-        access_config->ipv4_enable = json_boolean_value(value);
-    } else {
-        access_config->ipv4_enable = ctx->config.ipv4_enable;
-    }
-    value = json_object_get(access_interface, "ipv6");
-    if (json_is_boolean(value)) {
-        access_config->ipv6_enable = json_boolean_value(value);
-    } else {
-        access_config->ipv6_enable = ctx->config.ipv6_enable;
-    }
     value = json_object_get(access_interface, "dhcp");
     if (json_is_boolean(value)) {
         access_config->dhcp_enable = json_boolean_value(value);
     } else {
         access_config->dhcp_enable = ctx->config.dhcp_enable;
     }
+    value = json_object_get(access_interface, "ipv4");
+    if (json_is_boolean(value)) {
+        access_config->ipv4_enable = json_boolean_value(value);
+    } else {
+        if (access_config->dhcp_enable || access_config->static_ip) {
+            access_config->ipv4_enable = ctx->config.ipv4_enable;
+        } else {
+            access_config->ipv4_enable = false;
+        }
+    }
     value = json_object_get(access_interface, "dhcpv6");
     if (json_is_boolean(value)) {
         access_config->dhcpv6_enable = json_boolean_value(value);
     } else {
         access_config->dhcpv6_enable = ctx->config.dhcpv6_enable;
+    }
+    value = json_object_get(access_interface, "ipv6");
+    if (json_is_boolean(value)) {
+        access_config->ipv6_enable = json_boolean_value(value);
+    } else {
+        access_config->ipv6_enable = ctx->config.ipv6_enable;
     }
     value = json_object_get(access_interface, "igmp-autostart");
     if (json_is_boolean(value)) {
@@ -506,7 +510,6 @@ json_parse_access_interface (bbl_ctx_s *ctx, json_t *access_interface, bbl_acces
         fprintf(stderr, "JSON config error: Missing access->cfm-ma-name\n");
         return false;
     }
-
     return true;
 }
 

--- a/src/bbl_ctrl.c
+++ b/src/bbl_ctrl.c
@@ -507,7 +507,7 @@ bbl_ctrl_session_info(int fd, bbl_ctx_s *ctx, uint32_t session_id, json_t* argum
             root = json_pack("{ss si s{ss si ss ss si si ss ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* si si si so*}}",
                         "status", "ok",
                         "code", 200,
-                        "session-information",
+                        "session-info",
                         "type", "pppoe",
                         "session-id", session->session_id,
                         "session-state", session_state_string(session->session_state),
@@ -555,7 +555,7 @@ bbl_ctrl_session_info(int fd, bbl_ctx_s *ctx, uint32_t session_id, json_t* argum
             root = json_pack("{ss si s{ss si ss ss si si ss ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* ss* si si si si si si si si si si si si ss* si si si si si si si si si si si si ss* ss* si si si so*}}",
                         "status", "ok",
                         "code", 200,
-                        "session-information",
+                        "session-info",
                         "type", "ipoe",
                         "session-id", session->session_id,
                         "session-state", session_state_string(session->session_state),
@@ -1179,7 +1179,7 @@ bbl_ctrl_sessions_pending(int fd, bbl_ctx_s *ctx, uint32_t session_id __attribut
     root = json_pack("{ss si so}",
                      "status", "ok",
                      "code", 200,
-                     "session-pending", json_sessions);
+                     "sessions-pending", json_sessions);
     if(root) {
         result = json_dumpfd(root, fd, 0);
         json_decref(root);

--- a/src/bbl_ctx.c
+++ b/src/bbl_ctx.c
@@ -79,10 +79,10 @@ bbl_ctx_add (void)
     ctx->flow_id = 1;
 
     /* Initialize hash table dictionaries. */
-    ctx->vlan_session_dict = hashtable2_dict_new((dict_compare_func)bbl_compare_key64, bbl_key64_hash, BBL_SESSION_HASHTABLE_SIZE);
-    ctx->l2tp_session_dict = hashtable2_dict_new((dict_compare_func)bbl_compare_key32, bbl_key32_hash, BBL_SESSION_HASHTABLE_SIZE);
-    ctx->li_flow_dict = hashtable2_dict_new((dict_compare_func)bbl_compare_key32, bbl_key32_hash, BBL_LI_HASHTABLE_SIZE);
-    ctx->stream_flow_dict = hashtable2_dict_new((dict_compare_func)bbl_compare_key64, bbl_key64_hash, BBL_STREAM_FLOW_HASHTABLE_SIZE);
+    ctx->vlan_session_dict = hashtable_dict_new((dict_compare_func)bbl_compare_key64, bbl_key64_hash, BBL_SESSION_HASHTABLE_SIZE);
+    ctx->l2tp_session_dict = hashtable_dict_new((dict_compare_func)bbl_compare_key32, bbl_key32_hash, BBL_SESSION_HASHTABLE_SIZE);
+    ctx->li_flow_dict = hashtable_dict_new((dict_compare_func)bbl_compare_key32, bbl_key32_hash, BBL_LI_HASHTABLE_SIZE);
+    ctx->stream_flow_dict = hashtable_dict_new((dict_compare_func)bbl_compare_key64, bbl_key64_hash, BBL_STREAM_FLOW_HASHTABLE_SIZE);
 
     return ctx;
 }

--- a/src/bbl_io.c
+++ b/src/bbl_io.c
@@ -35,11 +35,6 @@ bbl_io_packet_mmap_rx_job (timer_s *timer) {
     if (!interface) {
         return;
     }
-    ctx = interface->ctx;
-
-
-    /* Get RX timestamp */
-    clock_gettime(CLOCK_MONOTONIC, &interface->rx_timestamp);
 
     frame_ptr = interface->io.ring_rx + (interface->io.cursor_rx * interface->io.req_rx.tp_frame_size);
     tphdr = (struct tpacket2_hdr*)frame_ptr;
@@ -52,7 +47,13 @@ bbl_io_packet_mmap_rx_job (timer_s *timer) {
             LOG(IO, "Failed to RX poll interface %s", interface->name);
         }
         interface->stats.poll_rx++;
+        return;
     }
+
+    ctx = interface->ctx;
+
+    /* Get RX timestamp */
+    clock_gettime(CLOCK_MONOTONIC, &interface->rx_timestamp);
 
     while ((tphdr->tp_status & TP_STATUS_USER)) {
         eth_start = (uint8_t*)tphdr + tphdr->tp_mac;

--- a/src/bbl_l2tp.c
+++ b/src/bbl_l2tp.c
@@ -873,6 +873,9 @@ bbl_l2tp_data_rx(bbl_ethernet_header_t *eth, bbl_l2tp_t *l2tp, bbl_interface_s *
         case PROTOCOL_LCP:
             lcp_rx = (bbl_lcp_t*)l2tp->next;
             if(lcp_rx->code == PPP_CODE_TERM_REQUEST) {
+                l2tp_session->disconnect_code = 3;
+                l2tp_session->disconnect_protocol = 0;
+                l2tp_session->disconnect_direction = 1;
                 bbl_l2tp_send(l2tp_session->tunnel, l2tp_session, L2TP_MESSAGE_CDN);
                 return bbl_l2tp_session_delete(l2tp_session);
             }

--- a/src/bbl_l2tp.c
+++ b/src/bbl_l2tp.c
@@ -853,7 +853,7 @@ bbl_l2tp_data_rx(bbl_ethernet_header_t *eth, bbl_l2tp_t *l2tp, bbl_interface_s *
     bbl_udp_t   *udp;
     bbl_bbl_t   *bbl;
 
-    char reply_message[sizeof(L2TP_REPLY_MESSAGE)+6];
+    char reply_message[sizeof(L2TP_REPLY_MESSAGE)+16];
 
     bbl_stream *stream;
     void **search = NULL;

--- a/src/bbl_l2tp.h
+++ b/src/bbl_l2tp.h
@@ -249,9 +249,14 @@ typedef struct bbl_l2tp_session_
     uint8_t ipcp_state;
     uint8_t ip6cp_state;
 
-    uint16_t result_code;
-    uint16_t error_code;
-    char* error_message;
+    uint16_t result_code; /* RFC2661 Result Code */
+    uint16_t error_code; /* RFC2661 Error Code */
+    char* error_message; /* RFC2661 Error Message */
+
+    uint16_t disconnect_code; /* RFC3145 Disconnect Cause Code */
+    uint16_t disconnect_protocol; /* RFC3145 Disconnect Cause Protocol */
+    uint16_t disconnect_direction; /* RFC3145 Disconnect Cause Direction */
+    char* disconnect_message; /* RFC3145 Disconnect Cause Message */
 
     /* The following members must be freed
      * if session is destroyed! */
@@ -272,6 +277,8 @@ const char* l2tp_message_string(l2tp_message_type type);
 const char* l2tp_tunnel_state_string(l2tp_tunnel_state_t state);
 const char* l2tp_session_state_string(l2tp_session_state_t state);
 
+void bbl_l2tp_session_delete(bbl_l2tp_session_t *l2tp_session);
+void bbl_l2tp_tunnel_update_state(bbl_l2tp_tunnel_t *l2tp_tunnel, l2tp_tunnel_state_t state);
 void bbl_l2tp_send(bbl_l2tp_tunnel_t *l2tp_tunnel, bbl_l2tp_session_t *l2tp_session, l2tp_message_type l2tp_type);
 void bbl_l2tp_handler_rx(bbl_ethernet_header_t *eth, bbl_l2tp_t *l2tp, bbl_interface_s *interface);
 void bbl_l2tp_stop_all_tunnel(bbl_ctx_s *ctx);

--- a/src/bbl_protocols.c
+++ b/src/bbl_protocols.c
@@ -2093,6 +2093,7 @@ decode_dhcpv6_ia_na(uint8_t *buf, uint16_t len, bbl_dhcpv6_t *dhcpv6) {
                 dhcpv6->ia_na_address = (ipv6addr_t*)(buf);
                 dhcpv6->ia_na_preferred_lifetime = be32toh(*(uint32_t*)(buf+16));
                 dhcpv6->ia_na_valid_lifetime = be32toh(*(uint32_t*)(buf+20));
+                break;
             default:
                 break;
         }
@@ -2134,6 +2135,7 @@ decode_dhcpv6_ia_pd(uint8_t *buf, uint16_t len, bbl_dhcpv6_t *dhcpv6) {
                 dhcpv6->ia_pd_preferred_lifetime = be32toh(*(uint32_t*)(buf));
                 dhcpv6->ia_pd_valid_lifetime = be32toh(*(uint32_t*)(buf+4));
                 dhcpv6->ia_pd_prefix = (ipv6_prefix*)(buf+8);
+                break;
             default:
                 break;
         }

--- a/src/bbl_rx.c
+++ b/src/bbl_rx.c
@@ -958,8 +958,10 @@ bbl_rx_ip6cp(bbl_ethernet_header_t *eth, bbl_interface_s *interface, bbl_session
                     session->link_local_ipv6_address[0] = 0xfe;
                     session->link_local_ipv6_address[1] = 0x80;
                     *(uint64_t*)&session->link_local_ipv6_address[8] = session->ip6cp_ipv6_identifier;
-                    session->send_requests |= BBL_SEND_ICMPV6_RS;
-                    bbl_session_tx_qnode_insert(session);
+                    if(session->l2tp == false) {
+                        session->send_requests |= BBL_SEND_ICMPV6_RS;
+                        bbl_session_tx_qnode_insert(session);
+                    }
                     break;
                 default:
                     break;
@@ -990,8 +992,10 @@ bbl_rx_ip6cp(bbl_ethernet_header_t *eth, bbl_interface_s *interface, bbl_session
                     session->link_local_ipv6_address[0] = 0xfe;
                     session->link_local_ipv6_address[1] = 0x80;
                     *(uint64_t*)&session->link_local_ipv6_address[8] = session->ip6cp_ipv6_identifier;
-                    session->send_requests |= BBL_SEND_ICMPV6_RS;
-                    bbl_session_tx_qnode_insert(session);
+                    if(session->l2tp == false) {
+                        session->send_requests |= BBL_SEND_ICMPV6_RS;
+                        bbl_session_tx_qnode_insert(session);
+                    }
                     break;
                 default:
                     break;

--- a/src/bbl_stream.c
+++ b/src/bbl_stream.c
@@ -34,14 +34,14 @@ bbl_stream_can_send(bbl_stream *stream) {
                     }
                     break;
                 case STREAM_IPV6:
-                    if(session->ip6cp_state == BBL_PPP_OPENED && 
-                       session->icmpv6_ra_received && 
+                    if(session->ip6cp_state == BBL_PPP_OPENED &&
+                       session->icmpv6_ra_received &&
                        *(uint64_t*)session->ipv6_address) {
                         return true;
                     }
                     break;
                 case STREAM_IPV6PD:
-                    if(session->ip6cp_state == BBL_PPP_OPENED && 
+                    if(session->ip6cp_state == BBL_PPP_OPENED &&
                        session->icmpv6_ra_received &&
                        *(uint64_t*)session->delegated_ipv6_address &&
                        session->dhcpv6_state >= BBL_DHCP_BOUND) {
@@ -59,7 +59,7 @@ bbl_stream_can_send(bbl_stream *stream) {
                     }
                     break;
                 case STREAM_IPV6:
-                    if(*(uint64_t*)session->ipv6_address && 
+                    if(*(uint64_t*)session->ipv6_address &&
                        session->icmpv6_ra_received) {
                         return true;
                     }
@@ -565,6 +565,10 @@ bbl_stream_tx_thread (void *thread_data) {
     /* Open new TX socket for thread. */
     fd_tx = socket(PF_PACKET, SOCK_RAW | SOCK_NONBLOCK, 0);
     if (fd_tx == -1) {
+        if (errno == EPERM) {
+            LOG(ERROR, "socket() for interface %s Permission denied: Are you root?\n", interface->name);
+            return NULL;
+        }
         LOG(ERROR, "socket() TX error %s (%d) for interface %s\n", strerror(errno), errno, interface->name);
         return NULL;
     }


### PR DESCRIPTION
#### New Features
+ UI enhancements
+ Support to run BNG Blaster as non-root user with capabilities
+ Add support for L2TP RFC3145
+ New command to terminate L2TP tunnel `l2tp-tunnel-terminate` with support to set result (RFC2661) codes
+ New command to terminate L2TP session `l2tp-session-terminate` with support to set result (RFC2661) and terminate (RFC3145) codes

#### Fixes
+ Minor L2TP Fixes
+ #33 

#### Internal Changes
+ Build enhancements
+ Performance enhancements
+ Hash table enhancements

#### Breaking Changes
The CLI tool `cli.py` was renamed to `bnglaster-cli` 
and will now be installed automatically to `sbin` 
directory.

The returned structure for the command
`session-info` has changed. 

```diff
{
    "status": "ok",
    "code": 200,
-    "session-information": {
+    "session-info": {
        "type": "pppoe"
        ...
    }
}
```

#### Community Contributors 

+ Istvan Ruzman (Istvan91) 