### PR TITLE
(Fix) cmake install prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,9 @@ if(BNGBLASTER_TESTS)
     add_subdirectory(test)
 endif()
 
-set(CMAKE_INSTALL_PREFIX /usr)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "..." FORCE)
+endif()
 
 install(TARGETS bngblaster DESTINATION sbin)
 install(PROGRAMS bngblaster-cli DESTINATION sbin)

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpgks": {
       "locked": {
-        "lastModified": 1621840840,
-        "narHash": "sha256-o6h6+d5ZwrFmOTe+ma9s1Z9kyHsCW1C84IA8RZ9/fIU=",
+        "lastModified": 1633351077,
+        "narHash": "sha256-z38JG4Bb0GtM1aF1pANVdp1dniMP23Yb3HnRoJRy2uU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea7d4aa9b8225abd6147339f0d56675d6f1f0fd1",
+        "rev": "14aef06d9b3ad1d07626bdbb16083b83f92dc6c1",
         "type": "github"
       },
       "original": {
@@ -33,12 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1622050916,
-        "narHash": "sha256-9fwhKSnWh2zDULooWHiCQCWBtjsY+N7NaI+hJEGCMbM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d4b7485fb66b727f822a1b94129c2af57166eab0",
-        "type": "github"
+        "lastModified": 1633351077,
+        "narHash": "sha256-z38JG4Bb0GtM1aF1pANVdp1dniMP23Yb3HnRoJRy2uU=",
+        "path": "/nix/store/z7qikyiq6zfhxc7k7721z3zcrlpxy9s6-source",
+        "rev": "14aef06d9b3ad1d07626bdbb16083b83f92dc6c1",
+        "type": "path"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,9 @@
 {
   inputs.nixpgks.url = "github:NixOS/nixpkgs/nixos-unstable";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.flake-utils = {
+    url = "github:numtide/flake-utils";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
 
   outputs = { self, nixpkgs, flake-utils, ... }@inputs:
     flake-utils.lib.eachDefaultSystem (system:


### PR DESCRIPTION
DO NOT set CMAKE_INSTALL_PREFIX unconditionally

The CMakeLists.txt set the CMAKE_INSTALL_PREFIX Parameter forcefully to "/usr". This breaks any usage of the cmake DESTDIR parameter or similar attempts to change the install directory via environment or command line parameters.

This patch will hide the setting of CMAKE_INSTALL_PREFIX behind the CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT flag to make the currently forced "/usr" install directory in the project default value, but allow users to overwrite the variable.

CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT is introduced in cmake 3.7.1 and since already cmake 3.10 is required, this change should not be breaking in any way.


In addition the flake/nixos dependencies were bumped.