### PR TITLE
fix ISIS holding timer #97

### DIFF
--- a/code/bngblaster/src/isis/isis_adjacency.c
+++ b/code/bngblaster/src/isis/isis_adjacency.c
@@ -145,6 +145,7 @@ isis_adjacency_down(isis_adjacency_t *adjacency) {
     timer_del(adjacency->timer_retry);
     timer_del(adjacency->timer_csnp);
     timer_del(adjacency->timer_csnp_next);
+    timer_del(adjacency->timer_holding);
 
     if(ctx->routing_sessions) ctx->routing_sessions--;
 }

--- a/code/bngblaster/src/isis/isis_adjacency.c
+++ b/code/bngblaster/src/isis/isis_adjacency.c
@@ -94,8 +94,10 @@ isis_adjacency_up(isis_adjacency_t *adjacency) {
         return;
     }
 
-    LOG(ISIS, "ISIS %s adjacency UP on interface %s \n", 
-        isis_level_string(adjacency->level), adjacency->interface->name);
+    LOG(ISIS, "ISIS %s adjacency UP to %s on interface %s \n", 
+        isis_level_string(adjacency->level), 
+        isis_system_id_to_str(adjacency->peer->system_id),
+        adjacency->interface->name);
 
     adjacency->state = ISIS_ADJACENCY_STATE_UP;
 
@@ -136,8 +138,10 @@ isis_adjacency_down(isis_adjacency_t *adjacency) {
         return;
     }
 
-    LOG(ISIS, "ISIS %s adjacency DOWN on interface %s \n", 
-        isis_level_string(adjacency->level), adjacency->interface->name);
+    LOG(ISIS, "ISIS %s adjacency DOWN to %s on interface %s \n", 
+        isis_level_string(adjacency->level), 
+        isis_system_id_to_str(adjacency->peer->system_id),
+        adjacency->interface->name);
 
     adjacency->state = ISIS_ADJACENCY_STATE_DOWN;
 

--- a/code/bngblaster/src/isis/isis_ctrl.c
+++ b/code/bngblaster/src/isis/isis_ctrl.c
@@ -18,8 +18,9 @@ isis_ctrl_adjacency(isis_adjacency_t *adjacency) {
         return NULL;
     }
 
-    peer = json_pack("{ss}",
-                     "system-id", isis_system_id_to_str(adjacency->peer->system_id));
+    peer = json_pack("{ss si}",
+                     "system-id", isis_system_id_to_str(adjacency->peer->system_id),
+                     "holding-timer", adjacency->peer->holding_time);
 
     root = json_pack("{ss ss ss si ss so}",
                 "interface", adjacency->interface->name,
@@ -45,8 +46,9 @@ isis_ctrl_adjacency_p2p(isis_adjacency_p2p_t *adjacency) {
         return NULL;
     }
 
-    peer = json_pack("{ss}",
-                     "system-id", isis_system_id_to_str(adjacency->peer->system_id));
+    peer = json_pack("{ss si}",
+                     "system-id", isis_system_id_to_str(adjacency->peer->system_id),
+                     "holding-timer", adjacency->peer->holding_time);
 
     root = json_pack("{ss ss, ss si ss so}",
                      "interface", adjacency->interface->name,

--- a/code/bngblaster/src/isis/isis_def.h
+++ b/code/bngblaster/src/isis/isis_def.h
@@ -24,6 +24,7 @@
 
 #define ISIS_OFFSET_P2P_HELLO_LEVEL     8
 #define ISIS_OFFSET_P2P_HELLO_SYSTEM_ID 9
+#define ISIS_OFFSET_P2P_HELLO_HOLD_TIME 15
 #define ISIS_OFFSET_P2P_HELLO_LEN       17
 
 #define ISIS_OFFSET_CSNP_LEN            8
@@ -237,6 +238,7 @@ typedef struct isis_config_ {
 typedef struct isis_peer_ {
     uint8_t  level;
     uint8_t  system_id[ISIS_SYSTEM_ID_LEN];
+    uint16_t holding_time;
     char    *hostname;
 } isis_peer_t;
 
@@ -258,12 +260,12 @@ typedef struct isis_adjacency_ {
     struct timer_   *timer_csnp;
     struct timer_   *timer_csnp_next;
     struct timer_   *timer_psnp_next;
-    
+    struct timer_   *timer_holding;
+
     bool timer_psnp_started;
 
     uint8_t  level;
     uint8_t  state;
-    uint8_t  timeout;
     uint16_t window_size;
 
     uint32_t metric;
@@ -289,7 +291,6 @@ typedef struct isis_adjacency_p2p_ {
     
     uint8_t level;
     uint8_t state;
-    uint8_t timeout;
 
     struct {
         uint32_t hello_rx;

--- a/code/bngblaster/src/isis/isis_p2p_hello.c
+++ b/code/bngblaster/src/isis/isis_p2p_hello.c
@@ -14,6 +14,31 @@ isis_hello_timeout (timer_s *timer) {
     interface->send_requests |= BBL_IF_SEND_ISIS_P2P_HELLO;
 }
 
+void
+isis_holding_timeout(timer_s *timer) {
+    isis_adjacency_t *adjacency = timer->data;
+
+    LOG(ISIS, "ISIS %s holding timeout on interface %s\n",
+        isis_level_string(adjacency->level), adjacency->interface->name);
+
+    isis_adjacency_down(adjacency);
+    isis_lsp_self_update(adjacency->instance, adjacency->level);
+}
+
+static void
+isis_p2p_reset_holding_timers(bbl_interface_s *interface) {
+    isis_adjacency_t *adjacency;
+
+    for(int i=0; i<ISIS_LEVELS; i++) {
+        adjacency = interface->isis_adjacency[i];
+        if(adjacency) {
+            timer_add(&interface->ctx->timer_root, &adjacency->timer_holding, 
+                      "ISIS holding", adjacency->peer->holding_time, 0, adjacency, 
+                      &isis_holding_timeout);
+        }
+    }
+}
+
 /**
  * isis_p2p_hello_encode
  *
@@ -38,20 +63,6 @@ isis_p2p_hello_encode(bbl_interface_s *interface,
 
     isis_auth_type auth = ISIS_AUTH_NONE;
     char *key = NULL;
-
-    if(adjacency->timeout > 3 && adjacency->state != ISIS_P2P_ADJACENCY_STATE_DOWN) {
-        LOG(ISIS, "ISIS P2P-Hello timeout on interface %s\n",
-            interface->name);
-
-        adjacency->state = ISIS_P2P_ADJACENCY_STATE_DOWN;
-
-        for(int i=0; i<ISIS_LEVELS; i++) {
-            if(interface->isis_adjacency[i]) {
-                isis_adjacency_down(interface->isis_adjacency[i]);
-                isis_lsp_self_update(adjacency->instance, i+1);
-            }
-        }
-    }
 
     /* Start next timer ... */
     timer_add(&interface->ctx->timer_root, &interface->timer_isis_hello, 
@@ -98,7 +109,6 @@ isis_p2p_hello_encode(bbl_interface_s *interface,
         LOG(DEBUG, "ISIS TX %s on interface %s\n",
             isis_pdu_type_string(isis.type), interface->name);
         adjacency->stats.hello_tx++;
-        adjacency->timeout++;
     }
     return result;
 }
@@ -145,13 +155,14 @@ isis_p2p_hello_handler_rx(bbl_interface_s *interface, isis_pdu_t *pdu) {
         LOG(ISIS, "ISIS RX P2P-Hello authentication failed on interface %s\n",
             adjacency->interface->name);
     }
-
-    adjacency->timeout = 0;
     
     peer = adjacency->peer;
     peer->level = *PDU_OFFSET(pdu, ISIS_OFFSET_P2P_HELLO_LEVEL) & 0x03;
     memcpy(peer->system_id, PDU_OFFSET(pdu, ISIS_OFFSET_P2P_HELLO_SYSTEM_ID), ISIS_SYSTEM_ID_LEN);
-    
+    peer->holding_time = be16toh(*(uint16_t*)PDU_OFFSET(pdu, ISIS_OFFSET_P2P_HELLO_HOLD_TIME));
+
+    isis_p2p_reset_holding_timers(interface);
+
     tlv = isis_pdu_first_tlv(pdu);
     while(tlv) {
         switch (tlv->type) {


### PR DESCRIPTION

Following an example with holding timer 60 set on neighbour device. 

`sudo bngblaster-cli run.sock isis-adjacencies`
```json
{
    "status": "ok",
    "code": 200,
    "isis-adjacencies": [
        {
            "interface": "veth2",
            "type": "P2P",
            "level": "L1L2",
            "instance-id": 1,
            "adjacency-state": "Up",
            "peer": {
                "system-id": "0010.0100.1001",
                "holding-timer": 60
            }
        }
    ]
}
```
LOG:
```
Jul 06 09:44:51.278090 ISIS RX P2P-Hello on interface veth2
...
Jul 06 09:45:51.275741 ISIS TX L2-LSP 1000.0000.0010.00-00 (seq 40) on interface veth2
Jul 06 09:45:51.278134 ISIS L1 holding timeout on interface veth2
Jul 06 09:45:51.278169 ISIS L1 adjacency DOWN on interface veth2
Jul 06 09:45:51.278184 ISIS L2 holding timeout on interface veth2
Jul 06 09:45:51.278194 ISIS L2 adjacency DOWN on interface veth2

```