### PR TITLE
(partial) fix: versioning in flake.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,9 @@
 (import (
-  fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
-) {
-  src =  ./.;
-}).defaultNix
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+      sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+    }
+  ) {
+    src = ./.;
+  })
+.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpgks": {
       "locked": {
-        "lastModified": 1633351077,
-        "narHash": "sha256-z38JG4Bb0GtM1aF1pANVdp1dniMP23Yb3HnRoJRy2uU=",
+        "lastModified": 1658015103,
+        "narHash": "sha256-mO+23f3SO+fBzEvbxRe6GkSB5Xp43CT2sV8Rs8MYdz8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14aef06d9b3ad1d07626bdbb16083b83f92dc6c1",
+        "rev": "8f485713f5e6b6883a9b6959afa98688360a3ecb",
         "type": "github"
       },
       "original": {
@@ -33,10 +33,9 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1633351077,
-        "narHash": "sha256-z38JG4Bb0GtM1aF1pANVdp1dniMP23Yb3HnRoJRy2uU=",
-        "path": "/nix/store/z7qikyiq6zfhxc7k7721z3zcrlpxy9s6-source",
-        "rev": "14aef06d9b3ad1d07626bdbb16083b83f92dc6c1",
+        "lastModified": 0,
+        "narHash": "sha256-rFJNM0X/dxekT6EESSh80mlBGqztfN/XOF/oRL6in68=",
+        "path": "/nix/store/ia11pz7v8wag5gh54bbnl5c87qc9cjm7-source",
         "type": "path"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,61 +5,74 @@
     inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        inherit (nixpkgs) lib;
-        pkgs = nixpkgs.legacyPackages.${system};
-        buildTools = [ pkgs.cmake pkgs.ninja pkgs.gcc ];
-        dependencies = [ pkgs.ncurses pkgs.openssl pkgs.jansson ];
-        runTests = false;
-      in rec {
-        packages = {
-          libdict = pkgs.stdenv.mkDerivation {
-            pname = "libdict";
-            version = "1.0.1";
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  } @ inputs:
+    flake-utils.lib.eachDefaultSystem (system: let
+      inherit (nixpkgs) lib;
+      pkgs = nixpkgs.legacyPackages.${system};
+      buildTools = [pkgs.cmake pkgs.ninja pkgs.gcc];
+      dependencies = [pkgs.ncurses pkgs.openssl pkgs.jansson];
+      runTests = false;
+    in rec {
+      formatter = pkgs.alejandra;
+      packages = {
+        libdict = pkgs.stdenv.mkDerivation {
+          pname = "libdict";
+          version = "1.0.1";
 
-            src = pkgs.fetchFromGitHub {
-              owner = "rtbrick";
-              repo = "libdict";
-              rev = "fea9fb240cfa08dc3bbfe425fb78466dbbf1aa56";
-              sha256 = "rnAvurPnmILMAB3Ingjw0lRJB6lcjdmUtPO6R3ek6e4=";
-            };
-
-            cmakeFlags = [
-              "-DCMAKE_BUILD_TYPE=Release"
-              "-DLIBDICT_STATIC=YES"
-              "-DLIBDICT_TOOLS=NO"
-              "-DLIBDICT_TESTS=NO"
-              "-DLIBDICT_SHARED=YES"
-            ];
-
-            doCheck = false;
-
-            checkInputs = [ pkgs.cunit ];
-            nativeBuildInputs = buildTools;
-
+          src = pkgs.fetchFromGitHub {
+            owner = "rtbrick";
+            repo = "libdict";
+            rev = "fea9fb240cfa08dc3bbfe425fb78466dbbf1aa56";
+            sha256 = "rnAvurPnmILMAB3Ingjw0lRJB6lcjdmUtPO6R3ek6e4=";
           };
-          bngblaster = pkgs.stdenv.mkDerivation rec {
+
+          cmakeFlags = [
+            "-DCMAKE_BUILD_TYPE=Release"
+            "-DLIBDICT_STATIC=YES"
+            "-DLIBDICT_TOOLS=NO"
+            "-DLIBDICT_TESTS=NO"
+            "-DLIBDICT_SHARED=YES"
+          ];
+
+          doCheck = false;
+
+          checkInputs = [pkgs.cunit];
+          nativeBuildInputs = buildTools;
+        };
+        bngblaster = let
+          version = self.rev or "dirty";
+        in
+          pkgs.stdenv.mkDerivation rec {
+            inherit version;
             pname = "bngblaster";
-            version = "0.52";
             src = lib.cleanSource ./.;
 
             doCheck = true;
-            cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ]
-              ++ (if doCheck then [ "-DBNGBLASTER_TESTS=ON" ] else [ ]);
+            cmakeFlags =
+              ["-DCMAKE_BUILD_TYPE=Release" "-DGIT_REF=${self.shortRef or "dirty"}" "-DGIT_SHA=${version}"]
+              ++ (
+                if doCheck
+                then ["-DBNGBLASTER_TESTS=ON"]
+                else []
+              );
 
-            checkInputs = [ pkgs.cmocka pkgs.libpcap ];
+            checkInputs = [pkgs.cmocka pkgs.libpcap];
             nativeBuildInputs = buildTools;
-            buildInputs = dependencies ++ [ packages.libdict ];
+            buildInputs = dependencies ++ [packages.libdict];
           };
-        };
-        devShell = pkgs.mkShell {
-          buildInputs = dependencies
-            ++ [ packages.libdict pkgs.bashInteractive ];
-        };
-        defaultPackage = packages.bngblaster;
-        apps.bngblaster = flake-utils.lib.mkApp { drv = packages.bngblaster; };
-        defaultApp = apps.bngblaster;
-      });
+      };
+      devShell = pkgs.mkShell {
+        buildInputs =
+          dependencies
+          ++ [packages.libdict pkgs.bashInteractive];
+      };
+      defaultPackage = packages.bngblaster;
+      apps.bngblaster = flake-utils.lib.mkApp {drv = packages.bngblaster;};
+      defaultApp = apps.bngblaster;
+    });
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,9 @@
 (import (
-  fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
-) {
-  src =  ./.;
-}).shellNix
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+      sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+    }
+  ) {
+    src = ./.;
+  })
+.shellNix


### PR DESCRIPTION
Previously the version number was hard coded, with this patch the git
rev is used as the version number. Currently there is no way to get the
git tag for the version number in flakes, so it is not yet possible to
do proper "release" packages with nix flakes.