### PR TITLE
WIP: No need to check for chap challenge length

### DIFF
--- a/code/bngblaster/src/bbl_rx.c
+++ b/code/bngblaster/src/bbl_rx.c
@@ -907,9 +907,9 @@ bbl_rx_chap(bbl_ethernet_header_t *eth, bbl_interface_s *interface, bbl_session_
     if(session->session_state == BBL_PPP_AUTH) {
         switch(chap->code) {
             case CHAP_CODE_CHALLENGE:
-                if(chap->challenge_len != CHALLENGE_LEN) {
+                if(chap->challenge_len == 0) {
                     /* TODO: Add support for variable CHAP challenge lengths. */
-                    LOG(PPPOE, "CHAP (ID: %u) unsupported CHAP challenge length received (expected 16)\n", session->session_id);
+                    LOG(PPPOE, "CHAP (ID: %u) CHAP challenge length must be greater than 0\n", session->session_id);
                     bbl_session_update_state(ctx, session, BBL_PPP_TERMINATING);
                     session->lcp_request_code = PPP_CODE_TERM_REQUEST;
                     session->lcp_options_len = 0;


### PR DESCRIPTION
the chap challenge is only read by MD5_update, which accepts input
of any size (given the supplied length is correct). There are no other
uses for the (received) chap challenge; only the chap_response is sent back,
which is implicitly guranteed to be 16 bytes (the output of MD5_finalize).

(This commit needs testing)