### PR TITLE
Improve IPv6 Gateway resolution

### DIFF
--- a/code/bngblaster/src/bbl_protocols.h
+++ b/code/bngblaster/src/bbl_protocols.h
@@ -212,6 +212,7 @@
 
 #define ICMPV6_FLAGS_MANAGED            0x80
 #define ICMPV6_FLAGS_OTHER_CONFIG       0x40
+#define ICMPV6_OPTION_DEST_LINK_LAYER   2
 #define ICMPV6_OPTION_PREFIX            3
 #define ICMPV6_OPTION_DNS               25
 
@@ -799,6 +800,7 @@ typedef struct bbl_icmpv6_ {
     uint16_t     data_len;
     ipv6addr_t  *dns1;
     ipv6addr_t  *dns2;
+    uint8_t     *dst_mac;
 } bbl_icmpv6_s;
 
 typedef struct bbl_dhcpv6_ {


### PR DESCRIPTION
The previous implementation just checked wether the Neighbor Solicitation is from the gateway. This does not work in all cases.

To correctly resolve the the IPv6 Gateway this implementation checks received Solicitations if they include the expected Gateway and uses the MAC Address from the Link-Layer Destination Option (if included).