### PR TITLE
fix: build error with dpdk due to redefines

### DIFF
--- a/code/bngblaster/src/bbl_protocols.c
+++ b/code/bngblaster/src/bbl_protocols.c
@@ -3932,7 +3932,7 @@ decode_ethernet(uint8_t *buf, uint16_t len,
         }
         eth->vlan_outer_priority = *buf >> 5;
         eth->vlan_outer = be16toh(*(uint16_t*)buf);
-        eth->vlan_outer &= ETH_VLAN_ID_MAX;
+        eth->vlan_outer &= BBL_ETH_VLAN_ID_MAX;
 
         BUMP_BUFFER(buf, len, sizeof(uint16_t));
         eth->type = *(uint16_t*)buf;
@@ -3943,7 +3943,7 @@ decode_ethernet(uint8_t *buf, uint16_t len,
             }
             eth->vlan_inner_priority = *buf >> 5;
             eth->vlan_inner = be16toh(*(uint16_t*)buf);
-            eth->vlan_inner &= ETH_VLAN_ID_MAX;
+            eth->vlan_inner &= BBL_ETH_VLAN_ID_MAX;
             BUMP_BUFFER(buf, len, sizeof(uint16_t));
             eth->type = *(uint16_t*)buf;
             BUMP_BUFFER(buf, len, sizeof(uint16_t));
@@ -3952,7 +3952,7 @@ decode_ethernet(uint8_t *buf, uint16_t len,
                     return DECODE_ERROR;
                 }
                 eth->vlan_three = be16toh(*(uint16_t*)buf);
-                eth->vlan_three &= ETH_VLAN_ID_MAX;
+                eth->vlan_three &= BBL_ETH_VLAN_ID_MAX;
                 BUMP_BUFFER(buf, len, sizeof(uint16_t));
                 eth->type = *(uint16_t*)buf;
                 BUMP_BUFFER(buf, len, sizeof(uint16_t));

--- a/code/bngblaster/src/bbl_protocols.h
+++ b/code/bngblaster/src/bbl_protocols.h
@@ -87,8 +87,8 @@
 #define NB_ETH_TYPE_MPLS                   0x8847
 #endif
 
-#define ETH_VLAN_ID_MAX                 4095
-#define ETH_VLAN_PBIT_MAX               7
+#define BBL_ETH_VLAN_ID_MAX             4095
+#define BBL_ETH_VLAN_PBIT_MAX           7
 
 #define ETH_IEEE_802_3_MAX_LEN          1500
 

--- a/code/bngblaster/src/io/io_packet_mmap.c
+++ b/code/bngblaster/src/io/io_packet_mmap.c
@@ -72,7 +72,7 @@ io_packet_mmap_rx_job(timer_s *timer)
         io->stats.bytes += io->buf_len;
         decode_result = decode_ethernet(io->buf, io->buf_len, g_ctx->sp, SCRATCHPAD_LEN, &eth);
         if(decode_result == PROTOCOL_SUCCESS) {
-            vlan = tphdr->tp_vlan_tci & ETH_VLAN_ID_MAX;
+            vlan = tphdr->tp_vlan_tci & BBL_ETH_VLAN_ID_MAX;
             if(vlan && eth->vlan_outer != vlan) {
                 /* The outer VLAN is stripped from header */
                 eth->vlan_inner = eth->vlan_outer;

--- a/code/bngblaster/src/io/io_thread.c
+++ b/code/bngblaster/src/io/io_thread.c
@@ -66,7 +66,7 @@ io_thread_rx_handler(io_thread_s *thread, io_handle_s *io)
         /** Process */
         decode_result = decode_ethernet(io->buf, io->buf_len, thread->sp, SCRATCHPAD_LEN, &eth);
         if(decode_result == PROTOCOL_SUCCESS) {
-            vlan = io->vlan_tci & ETH_VLAN_ID_MAX;
+            vlan = io->vlan_tci & BBL_ETH_VLAN_ID_MAX;
             if(eth->vlan_outer != vlan) {
                 /* The outer VLAN is stripped from header */
                 eth->vlan_inner = eth->vlan_outer;
@@ -114,7 +114,7 @@ io_thread_main_rx_job(timer_s *timer)
             while((slot = bbl_txq_read_slot(thread->txq))) {
                 decode_result = decode_ethernet(slot->packet, slot->packet_len, g_ctx->sp, SCRATCHPAD_LEN, &eth);
                 if(decode_result == PROTOCOL_SUCCESS) {
-                    vlan = slot->vlan_tci & ETH_VLAN_ID_MAX;
+                    vlan = slot->vlan_tci & BBL_ETH_VLAN_ID_MAX;
                     if(vlan && eth->vlan_outer != vlan) {
                         /* Restore outer VLAN */
                         eth->vlan_inner = eth->vlan_outer;


### PR DESCRIPTION
bngblaster used the same defines as some dpdk headers. This caused a redifine warning, which got promoted to an error (cause of the -Werror flag).

Solution: change the defines to have a BBL_ prefix