### PR TITLE
ISIS extended auth config

### DIFF
--- a/code/bngblaster/src/bbl_config.c
+++ b/code/bngblaster/src/bbl_config.c
@@ -1166,6 +1166,7 @@ json_parse_isis_config(json_t *isis, isis_config_s *isis_config)
     }
     if(isis_config->level == 0 || isis_config->level > 3) {
         fprintf(stderr, "JSON config error: Invalid value for isis->level\n");
+        return false;
     }
 
     value = json_object_get(isis, "overload");
@@ -1189,20 +1190,70 @@ json_parse_isis_config(json_t *isis, isis_config_s *isis_config)
 
     if(json_unpack(isis, "{s:s}", "level1-auth-key", &s) == 0) {
         isis_config->level1_key = strdup(s);
-        isis_config->level1_auth = ISIS_AUTH_CLEARTEXT;
+        isis_config->level1_auth = ISIS_AUTH_NONE;
         if(json_unpack(isis, "{s:s}", "level1-auth-type", &s) == 0) {
             if(strcmp(s, "md5") == 0) {
                 isis_config->level1_auth = ISIS_AUTH_HMAC_MD5;
+            } else if(strcmp(s, "simple") == 0) {
+                isis_config->level1_auth = ISIS_AUTH_CLEARTEXT;
+            } else {
+                fprintf(stderr, "JSON config error: Invalid value for isis->level1-auth-type\n");
+                return false;
+            }
+        }
+        if(isis_config->level1_auth) {
+            value = json_object_get(isis, "level1-auth-hello");
+            if(json_is_boolean(value)) {
+                isis_config->level1_auth_hello  = json_boolean_value(value);
+            } else {
+                isis_config->level1_auth_hello  = true;
+            }
+            value = json_object_get(isis, "level1-auth-csnp");
+            if(json_is_boolean(value)) {
+                isis_config->level1_auth_csnp  = json_boolean_value(value);
+            } else {
+                isis_config->level1_auth_csnp  = true;
+            }
+            value = json_object_get(isis, "level1-auth-psnp");
+            if(json_is_boolean(value)) {
+                isis_config->level1_auth_psnp  = json_boolean_value(value);
+            } else {
+                isis_config->level1_auth_psnp  = true;
             }
         }
     }
 
     if(json_unpack(isis, "{s:s}", "level2-auth-key", &s) == 0) {
         isis_config->level2_key = strdup(s);
-        isis_config->level2_auth = ISIS_AUTH_CLEARTEXT;
+        isis_config->level2_auth = ISIS_AUTH_NONE;
         if(json_unpack(isis, "{s:s}", "level2-auth-type", &s) == 0) {
             if(strcmp(s, "md5") == 0) {
                 isis_config->level2_auth = ISIS_AUTH_HMAC_MD5;
+            } else if(strcmp(s, "simple") == 0) {
+                isis_config->level2_auth = ISIS_AUTH_CLEARTEXT;
+            } else {
+                fprintf(stderr, "JSON config error: Invalid value for isis->level2-auth-type\n");
+                return false;
+            }
+        }
+        if(isis_config->level2_auth) {
+            value = json_object_get(isis, "level2-auth-hello");
+            if(json_is_boolean(value)) {
+                isis_config->level2_auth_hello  = json_boolean_value(value);
+            } else {
+                isis_config->level2_auth_hello  = true;
+            }
+            value = json_object_get(isis, "level2-auth-csnp");
+            if(json_is_boolean(value)) {
+                isis_config->level2_auth_csnp  = json_boolean_value(value);
+            } else {
+                isis_config->level2_auth_csnp  = true;
+            }
+            value = json_object_get(isis, "level2-auth-psnp");
+            if(json_is_boolean(value)) {
+                isis_config->level2_auth_psnp  = json_boolean_value(value);
+            } else {
+                isis_config->level2_auth_psnp  = true;
             }
         }
     }

--- a/code/bngblaster/src/isis/isis_csnp.c
+++ b/code/bngblaster/src/isis/isis_csnp.c
@@ -44,13 +44,13 @@ isis_csnp_job(timer_s *timer)
     /* Build PDU */
     if(level == ISIS_LEVEL_1) {
         isis_pdu_init(&pdu, ISIS_PDU_L1_CSNP);
-        if(config->level1_auth && config->level1_key) {
+        if(config->level1_auth_csnp) {
             auth = config->level1_auth;
             key = config->level1_key;
         }
     } else {
         isis_pdu_init(&pdu, ISIS_PDU_L2_CSNP);
-        if(config->level2_auth && config->level2_key) {
+        if(config->level2_auth_csnp) {
             auth = config->level2_auth;
             key = config->level2_key;
         }
@@ -196,13 +196,14 @@ isis_csnp_handler_rx(bbl_network_interface_s *interface, isis_pdu_s *pdu, uint8_
     lsp_start = be64toh(*(uint64_t*)PDU_OFFSET(pdu, ISIS_OFFSET_CSNP_LSP_START));
     lsp_end = be64toh(*(uint64_t*)PDU_OFFSET(pdu, ISIS_OFFSET_CSNP_LSP_END));
 
-    if(level == ISIS_LEVEL_1 && config->level1_auth && config->level1_key) {
+    if(level == ISIS_LEVEL_1 && config->level1_auth_csnp) {
         auth = config->level1_auth;
         key = config->level1_key;
-    } else if(level == ISIS_LEVEL_2 && config->level2_auth && config->level2_key) {
+    } else if(level == ISIS_LEVEL_2 && config->level2_auth_csnp) {
         auth = config->level2_auth;
         key = config->level2_key;
     }
+
     if(!isis_pdu_validate_auth(pdu, auth, key)) {
         LOG(ISIS, "ISIS RX %s-CSNP authentication failed on interface %s\n",
             isis_level_string(level), interface->name);

--- a/code/bngblaster/src/isis/isis_def.h
+++ b/code/bngblaster/src/isis/isis_def.h
@@ -197,8 +197,15 @@ typedef struct isis_config_ {
 
     isis_auth_type      level1_auth;
     char               *level1_key;
+    bool                level1_auth_hello;
+    bool                level1_auth_csnp;
+    bool                level1_auth_psnp;
+
     isis_auth_type      level2_auth;
     char               *level2_key;
+    bool                level2_auth_hello;
+    bool                level2_auth_csnp;
+    bool                level2_auth_psnp;
 
     uint16_t            lsp_refresh_interval;
     uint16_t            lsp_lifetime;

--- a/code/bngblaster/src/isis/isis_lsp.c
+++ b/code/bngblaster/src/isis/isis_lsp.c
@@ -561,10 +561,10 @@ isis_lsp_handler_rx(bbl_network_interface_s *interface, isis_pdu_s *pdu, uint8_t
         isis_lsp_id_to_str(&lsp_id), 
         seq, interface->name);
 
-    if(level == ISIS_LEVEL_1 && config->level1_auth && config->level1_key) {
+    if(level == ISIS_LEVEL_1 && config->level1_auth) {
         auth = config->level1_auth;
         key = config->level1_key;
-    } else if(level == ISIS_LEVEL_2 && config->level2_auth && config->level2_key) {
+    } else if(level == ISIS_LEVEL_2 && config->level2_auth) {
         auth = config->level2_auth;
         key = config->level2_key;
     }

--- a/code/bngblaster/src/isis/isis_p2p_hello.c
+++ b/code/bngblaster/src/isis/isis_p2p_hello.c
@@ -80,10 +80,10 @@ isis_p2p_hello_encode(bbl_network_interface_s *interface,
               "ISIS Hello", config->hello_interval, 0, interface, 
               &isis_p2p_hello_timeout);
 
-    if(config->level1_auth && config->level1_key) {
+    if((adjacency->level & ISIS_LEVEL_1) && config->level1_auth_hello) {
         auth = config->level1_auth;
         key = config->level1_key;
-    } else if(config->level2_auth && config->level2_key) {
+    } else if((adjacency->level & ISIS_LEVEL_2) && config->level2_auth_hello) {
         auth = config->level2_auth;
         key = config->level2_key;
     }
@@ -155,10 +155,10 @@ isis_p2p_hello_handler_rx(bbl_network_interface_s *interface, isis_pdu_s *pdu)
 
     adjacency->stats.hello_rx++;
 
-    if(config->level1_auth && config->level1_key) {
+    if((adjacency->level & ISIS_LEVEL_1) && config->level1_auth_hello) {
         auth = config->level1_auth;
         key = config->level1_key;
-    } else if(config->level2_auth && config->level2_key) {
+    } else if((adjacency->level & ISIS_LEVEL_2) && config->level2_auth_hello) {
         auth = config->level2_auth;
         key = config->level2_key;
     }
@@ -188,7 +188,7 @@ isis_p2p_hello_handler_rx(bbl_network_interface_s *interface, isis_pdu_s *pdu)
     }
 
     if(state) {
-        switch (*state) {
+        switch(*state) {
             case ISIS_P2P_ADJACENCY_STATE_UP:
                 new_state = ISIS_P2P_ADJACENCY_STATE_UP;
                 break;

--- a/code/bngblaster/src/isis/isis_psnp.c
+++ b/code/bngblaster/src/isis/isis_psnp.c
@@ -43,13 +43,13 @@ isis_psnp_job (timer_s *timer)
     /* Build PDU */
     if(level == ISIS_LEVEL_1) {
         isis_pdu_init(&pdu, ISIS_PDU_L1_PSNP);
-        if(config->level1_auth && config->level1_key) {
+        if(config->level1_auth_psnp) {
             auth = config->level1_auth;
             key = config->level1_key;
         }
     } else {
         isis_pdu_init(&pdu, ISIS_PDU_L2_PSNP);
-        if(config->level2_auth && config->level2_key) {
+        if(config->level2_auth_psnp) {
             auth = config->level2_auth;
             key = config->level2_key;
         }
@@ -163,13 +163,14 @@ isis_psnp_handler_rx(bbl_network_interface_s *interface, isis_pdu_s *pdu, uint8_
 
     adjacency->stats.psnp_rx++;
     
-    if(level == ISIS_LEVEL_1 && config->level1_auth && config->level1_key) {
+    if(level == ISIS_LEVEL_1 && config->level1_auth_psnp) {
         auth = config->level1_auth;
         key = config->level1_key;
-    } else if(level == ISIS_LEVEL_2 && config->level2_auth && config->level2_key) {
+    } else if(level == ISIS_LEVEL_2 && config->level2_auth_psnp) {
         auth = config->level2_auth;
         key = config->level2_key;
     }
+
     if(!isis_pdu_validate_auth(pdu, auth, key)) {
         LOG(ISIS, "ISIS RX %s-PSNP authentication failed on interface %s\n",
             isis_level_string(level), interface->name);


### PR DESCRIPTION
New configuration to partly enable/disable authentication for hello, CSNP and PSNP. 
```
    "level1-auth-key": "SECRET",
    "level1-auth-type": "simple",
    "level1-auth-hello": false,
    "level1-auth-csnp": false,
    "level1-auth-psnp": false,
    "level2-auth-key": "VERY-SECRET",
    "level2-auth-type": "simple" 
    "level2-auth-hello": false,
    "level2-auth-csnp": false,
    "level2-auth-psnp": false, 
```