### PR TITLE
Draft: IPv6 Support for TCP and LDP

### DIFF
--- a/code/bngblaster/src/bbl_config.c
+++ b/code/bngblaster/src/bbl_config.c
@@ -1653,7 +1653,10 @@ json_parse_ldp_config(json_t *ldp, ldp_config_s *ldp_config)
     const char *schema[] = {
         "instance-id", "keepalive-time", "hold-time",
         "teardown-time", "hostname", "lsr-id",
-        "ipv4-transport-address", "raw-update-file"
+        "ipv4-transport", "ipv4-transport-address",
+        "ipv6-transport", "ipv6-transport-address",
+        "prefer-ipv4-transport"
+        "raw-update-file"
     };
     if(!schema_validate(ldp, "ldp", schema, 
     sizeof(schema)/sizeof(schema[0]))) {
@@ -1704,6 +1707,14 @@ json_parse_ldp_config(json_t *ldp, ldp_config_s *ldp_config)
         fprintf(stderr, "JSON config error: Invalid value for ldp->lsr-id\n");
         return false;
     }
+
+    if(json_unpack(ldp, "{s:s}", "ipv6-transport-address", &s) == 0) {
+        if(!inet_pton(AF_INET6, s, &ldp_config->ipv6_transport_address)) {
+            fprintf(stderr, "JSON config error: Invalid value for ldp->ipv6-transport-address\n");
+            return false;
+        }
+    }
+
     if(json_unpack(ldp, "{s:s}", "ipv4-transport-address", &s) == 0) {
         if(!inet_pton(AF_INET, s, &ldp_config->ipv4_transport_address)) {
             fprintf(stderr, "JSON config error: Invalid value for ldp->ipv4-transport-address\n");
@@ -1711,6 +1722,16 @@ json_parse_ldp_config(json_t *ldp, ldp_config_s *ldp_config)
         }
     } else {
         ldp_config->ipv4_transport_address = ldp_config->lsr_id;
+    }
+
+    value = json_object_get(ldp, "no-ipv4-transport");
+    if(json_is_boolean(value)) {
+        ldp_config->no_ipv4_transport = json_boolean_value(value);
+    }
+
+    value = json_object_get(ldp, "prefer-ipv4-transport");
+    if(json_is_boolean(value)) {
+        ldp_config->prefer_ipv4_transport = json_boolean_value(value);
     }
 
     if(json_unpack(ldp, "{s:s}", "raw-update-file", &s) == 0) {

--- a/code/bngblaster/src/bbl_config.c
+++ b/code/bngblaster/src/bbl_config.c
@@ -1653,9 +1653,8 @@ json_parse_ldp_config(json_t *ldp, ldp_config_s *ldp_config)
     const char *schema[] = {
         "instance-id", "keepalive-time", "hold-time",
         "teardown-time", "hostname", "lsr-id",
-        "ipv4-transport", "ipv4-transport-address",
-        "ipv6-transport", "ipv6-transport-address",
-        "prefer-ipv4-transport"
+        "ipv6-transport-address", "ipv4-transport-address",
+        "no-ipv4-transport", "prefer-ipv4-transport",
         "raw-update-file"
     };
     if(!schema_validate(ldp, "ldp", schema, 
@@ -1758,7 +1757,8 @@ json_parse_stream(json_t *stream, bbl_stream_config_s *stream_config)
         "priority", "vlan-priority", "pps",
         "bps", "Kbps", "Mbps",
         "Gbps", "max-packets", "start-delay",
-        "ldp-ipv4-lookup-address", "access-ipv4-source-address", "access-ipv6-source-address",
+        "ldp-ipv4-lookup-address", "ldp-ipv6-lookup-address", 
+        "access-ipv4-source-address", "access-ipv6-source-address",
         "network-ipv4-address", "network-ipv6-address", "destination-ipv4-address",
         "destination-ipv6-address", "ipv4-df", "tx-label1",
         "tx-label1-exp", "tx-label1-ttl", "tx-label2",
@@ -1936,6 +1936,13 @@ json_parse_stream(json_t *stream, bbl_stream_config_s *stream_config)
     if(json_unpack(stream, "{s:s}", "ldp-ipv4-lookup-address", &s) == 0) {
         if(!inet_pton(AF_INET, s, &stream_config->ipv4_ldp_lookup_address)) {
             fprintf(stderr, "JSON config error: Invalid value for stream->ldp-ipv4-lookup-address\n");
+            return false;
+        }
+    }
+
+    if(json_unpack(stream, "{s:s}", "ldp-ipv6-lookup-address", &s) == 0) {
+        if(!inet_pton(AF_INET6, s, &stream_config->ipv6_ldp_lookup_address)) {
+            fprintf(stderr, "JSON config error: Invalid value for stream->ldp-ipv6-lookup-address\n");
             return false;
         }
     }

--- a/code/bngblaster/src/bbl_def.h
+++ b/code/bngblaster/src/bbl_def.h
@@ -99,7 +99,8 @@ static const ipv6_prefix mock_ipv6_ia_pd = {
 #define BBL_IF_SEND_ICMPV6_NS       0x00000002
 #define BBL_IF_SEND_ICMPV6_RA       0x00000004
 #define BBL_IF_SEND_ISIS_P2P_HELLO  0x00000008
-#define BBL_IF_SEND_LDP_HELLO       0x00000010
+#define BBL_IF_SEND_LDP_HELLO_IPV4  0x00000010
+#define BBL_IF_SEND_LDP_HELLO_IPV6  0x00000020
 
 #define BBL_AVG_SAMPLES             5
 #define BBL_MAX_STREAM_OVERHEAD     128

--- a/code/bngblaster/src/bbl_protocols.h
+++ b/code/bngblaster/src/bbl_protocols.h
@@ -552,11 +552,13 @@ typedef struct bbl_isis_ {
 } bbl_isis_s;
 
 typedef struct bbl_ldp_hello_ {
-    uint32_t lsr_id;
-    uint16_t label_space_id;
-    uint32_t msg_id;
-    uint32_t ipv4_transport_address;
-    uint16_t hold_time;
+    uint32_t    lsr_id;
+    uint16_t    label_space_id;
+    uint16_t    hold_time;
+    uint32_t    msg_id;
+    uint32_t    ipv4_transport_address;
+    ipv6addr_t *ipv6_transport_address;
+    uint8_t     dual_stack_capability;
 } bbl_ldp_hello_s;
 
 typedef struct bbl_bbl_ {

--- a/code/bngblaster/src/bbl_stream.c
+++ b/code/bngblaster/src/bbl_stream.c
@@ -1159,6 +1159,10 @@ bbl_stream_ldp_lookup(bbl_stream_s *stream)
             stream->ldp_entry = ldb_db_lookup_ipv4(
                 stream->network_interface->ldp_adjacency->instance, 
                 stream->config->ipv4_ldp_lookup_address);
+        } else if (*(uint64_t*)stream->config->ipv6_ldp_lookup_address) {
+            stream->ldp_entry = ldb_db_lookup_ipv6(
+                stream->network_interface->ldp_adjacency->instance, 
+                &stream->config->ipv6_ldp_lookup_address);
         }
     }
 
@@ -1631,7 +1635,9 @@ bbl_stream_session_add(bbl_stream_config_s *config, bbl_session_s *session)
         if(network_interface) {
             stream->network_interface = network_interface;
             stream->tx_interface = network_interface->interface;
-            if(config->ipv4_ldp_lookup_address && network_interface->ldp_adjacency) {
+            if(network_interface->ldp_adjacency && 
+               (config->ipv4_ldp_lookup_address || 
+                *(uint64_t*)stream->config->ipv6_ldp_lookup_address)) {
                 stream->ldp_lookup = true;
             }
             bbl_stream_add(stream);
@@ -1772,7 +1778,9 @@ bbl_stream_init() {
                 stream->network_interface = network_interface;
                 stream->tx_interface = network_interface->interface;
                 stream->tx_interval = tx_interval;
-                if(config->ipv4_ldp_lookup_address && network_interface->ldp_adjacency) {
+                if(network_interface->ldp_adjacency && 
+                   (config->ipv4_ldp_lookup_address || 
+                    *(uint64_t*)stream->config->ipv6_ldp_lookup_address)) {
                     stream->ldp_lookup = true;
                 }
                 result = dict_insert(g_ctx->stream_flow_dict, &stream->flow_id);

--- a/code/bngblaster/src/bbl_stream.h
+++ b/code/bngblaster/src/bbl_stream.h
@@ -34,6 +34,7 @@ typedef struct bbl_stream_config_
     uint32_t ipv4_access_src_address; /* overwrite default IPv4 access address */
     ipv6addr_t ipv6_access_src_address; /* overwrite default IPv6 access address */
     uint32_t ipv4_network_address; /* overwrite default IPv4 network address */
+    ipv6addr_t ipv6_ldp_lookup_address;
     ipv6addr_t ipv6_network_address; /* overwrite default IPv6 network address */
     uint32_t ipv4_destination_address; /* overwrite IPv4 destination address */
     ipv6addr_t ipv6_destination_address; /* overwrite IPv6 destination address */

--- a/code/bngblaster/src/bbl_tcp.h
+++ b/code/bngblaster/src/bbl_tcp.h
@@ -39,12 +39,10 @@ typedef struct bbl_tcp_ctx_
     uint8_t af; /* AF_INET or AF_INET6 */
 
     uint16_t   local_port;
-    ipv4addr_t local_ipv4;
-    ipv6addr_t local_ipv6;
+    ip_addr_t  local_addr;
 
     uint16_t   remote_port;
-    ipv4addr_t remote_ipv4;
-    ipv6addr_t remote_ipv6;
+    ip_addr_t  remote_addr;
     
     struct tcp_pcb *pcb;
 
@@ -90,13 +88,16 @@ bbl_tcp_ctx_s *
 bbl_tcp_ipv4_listen(bbl_network_interface_s *interface, ipv4addr_t *address, uint16_t port);
 
 bbl_tcp_ctx_s *
-bbl_tcp_ipv4_connect(bbl_network_interface_s *interface, ipv4addr_t *src, ipv4addr_t *dst, uint16_t port);
+bbl_tcp_ipv6_listen(bbl_network_interface_s *interface, ipv6addr_t *address, uint16_t port);
 
-void
-bbl_tcp_ipv4_rx(bbl_network_interface_s *interface, bbl_ethernet_header_s *eth, bbl_ipv4_s *ipv4);
+bbl_tcp_ctx_s *
+bbl_tcp_ipv4_connect(bbl_network_interface_s *interface, ipv4addr_t *src, ipv4addr_t *dst, uint16_t port);
 
 bbl_tcp_ctx_s *
 bbl_tcp_ipv6_connect(bbl_network_interface_s *interface, ipv6addr_t *src, ipv6addr_t *dst, uint16_t port);
+
+void
+bbl_tcp_ipv4_rx(bbl_network_interface_s *interface, bbl_ethernet_header_s *eth, bbl_ipv4_s *ipv4);
 
 void
 bbl_tcp_ipv6_rx(bbl_network_interface_s *interface, bbl_ethernet_header_s *eth, bbl_ipv6_s *ipv6);

--- a/code/bngblaster/src/bbl_tx.c
+++ b/code/bngblaster/src/bbl_tx.c
@@ -1465,9 +1465,12 @@ bbl_tx_encode_network_packet(bbl_network_interface_s *interface, uint8_t *buf, u
     } else if(interface->send_requests & BBL_IF_SEND_ISIS_P2P_HELLO) {
         interface->send_requests &= ~BBL_IF_SEND_ISIS_P2P_HELLO;
         result = isis_p2p_hello_encode(interface, buf, len, &eth);
-    } else if(interface->send_requests & BBL_IF_SEND_LDP_HELLO) {
-        interface->send_requests &= ~BBL_IF_SEND_LDP_HELLO;
-        result = ldp_hello_encode(interface, buf, len, &eth);
+    } else if(interface->send_requests & BBL_IF_SEND_LDP_HELLO_IPV6) {
+        interface->send_requests &= ~BBL_IF_SEND_LDP_HELLO_IPV6;
+        result = ldp_hello_ipv6_encode(interface, buf, len, &eth);
+    } else if(interface->send_requests & BBL_IF_SEND_LDP_HELLO_IPV4) {
+        interface->send_requests &= ~BBL_IF_SEND_LDP_HELLO_IPV4;
+        result = ldp_hello_ipv4_encode(interface, buf, len, &eth);
     } else {
         interface->send_requests = 0;
     }

--- a/code/bngblaster/src/ldp/ldp_ctrl.c
+++ b/code/bngblaster/src/ldp/ldp_ctrl.c
@@ -86,6 +86,8 @@ ldp_ctrl_session_json(ldp_session_s *session)
     json_t *stats = NULL;
     
     const char *raw_update_file = NULL;
+    char *local_address;
+    char *peer_address;
 
     if(!session) {
         return NULL;
@@ -107,12 +109,20 @@ ldp_ctrl_session_json(ldp_session_s *session)
         return NULL;
     }
 
+    if(session->ipv6) {
+        local_address = format_ipv6_address(&session->local.ipv6_address);
+        peer_address = format_ipv6_address(&session->peer.ipv6_address);
+    } else {
+        local_address = format_ipv4_address(&session->local.ipv4_address);
+        peer_address = format_ipv4_address(&session->peer.ipv4_address);
+    }
+
     root = json_pack("{si ss ss ss ss ss ss si ss* ss* so*}",
                      "ldp-instance-id", session->instance->config->id,
                      "interface", session->interface->name,
-                     "local-address", format_ipv4_address(&session->local.ipv4_address),
+                     "local-address", local_address,
                      "local-identifier", ldp_id_to_str(session->local.lsr_id, session->local.label_space_id),
-                     "peer-address", format_ipv4_address(&session->peer.ipv4_address),
+                     "peer-address", peer_address,
                      "peer-identifier", ldp_id_to_str(session->peer.lsr_id, session->peer.label_space_id),
                      "state", ldp_session_state_string(session->state),
                      "state-transitions", session->state_transitions,

--- a/code/bngblaster/src/ldp/ldp_db.c
+++ b/code/bngblaster/src/ldp/ldp_db.c
@@ -19,9 +19,7 @@ ldb_db_ipv4_compare(void *id1, void *id2)
 int
 ldb_db_ipv6_compare(void *id1, void *id2)
 {
-    const uint64_t a = *(const uint64_t*)id1;
-    const uint64_t b = *(const uint64_t*)id2;
-    return (a > b) - (a < b);
+    return memcmp(id1, id2, sizeof(ipv6addr_t));
 }
 
 bool
@@ -72,6 +70,54 @@ ldb_db_lookup_ipv4(ldp_instance_s *instance, uint32_t address)
     ldp_db_entry_s *entry;
 
     search = hb_tree_search(instance->db.ipv4, &address);
+    if(search) {
+        entry = *search;
+        return entry;
+    }
+    return NULL;
+}
+
+bool
+ldb_db_add_ipv6(ldp_session_s *session, ipv6_prefix *prefix, uint32_t label)
+{
+    void **search = NULL;
+    ldp_instance_s *instance = session->instance;
+    ldp_db_entry_s *entry;
+    dict_insert_result result;
+
+    search = hb_tree_search(instance->db.ipv6, &prefix->address);
+    if(search) {
+        entry = *search;
+        entry->version++;
+    } else {
+        entry = calloc(1, sizeof(ldp_db_entry_s));
+        entry->afi = IANA_AFI_IPV6;
+        memcpy(&entry->prefix.ipv6, prefix, sizeof(ipv6_prefix));
+        result = hb_tree_insert(instance->db.ipv6, &entry->prefix.ipv6.address);
+        if(result.inserted) {
+            *result.datum_ptr = entry;
+        } else {
+            LOG(ERROR, "LDP (%s - %s) failed to add IPv6 entry to database\n",
+                ldp_id_to_str(session->local.lsr_id, session->local.label_space_id),
+                ldp_id_to_str(session->peer.lsr_id, session->peer.label_space_id));
+            return false;
+        }
+    }
+    entry->active = true;
+    entry->prefix.ipv6.len = prefix->len;
+    entry->label = label;
+    entry->source = session;
+    return true;
+
+}
+
+ldp_db_entry_s *
+ldb_db_lookup_ipv6(ldp_instance_s *instance, ipv6addr_t *address)
+{
+    void **search = NULL;
+    ldp_db_entry_s *entry;
+
+    search = hb_tree_search(instance->db.ipv6, address);
     if(search) {
         entry = *search;
         return entry;

--- a/code/bngblaster/src/ldp/ldp_db.h
+++ b/code/bngblaster/src/ldp/ldp_db.h
@@ -18,4 +18,10 @@ ldb_db_add_ipv4(ldp_session_s *session, ipv4_prefix *prefix, uint32_t label);
 ldp_db_entry_s *
 ldb_db_lookup_ipv4(ldp_instance_s *instance, uint32_t address);
 
+bool
+ldb_db_add_ipv6(ldp_session_s *session, ipv6_prefix *prefix, uint32_t label);
+
+ldp_db_entry_s *
+ldb_db_lookup_ipv6(ldp_instance_s *instance, ipv6addr_t *address);
+
 #endif

--- a/code/bngblaster/src/ldp/ldp_def.h
+++ b/code/bngblaster/src/ldp/ldp_def.h
@@ -33,6 +33,7 @@
 #define LDP_MESSAGE_TYPE_LABEL_RELEASE              0x0403
 #define LDP_MESSAGE_TYPE_ABORT_REQUEST              0x0404
 
+#define LDP_TLV_TYPE_MASK                           0x3FFF
 #define LDP_TLV_TYPE_FEC                            0x0100
 #define LDP_TLV_TYPE_ADDRESS_LIST                   0x0101
 #define LDP_TLV_TYPE_HOP_COUNT                      0x0103
@@ -48,6 +49,7 @@
 #define LDP_TLV_TYPE_IPV6_TRANSPORT_ADDRESS         0x0403
 #define LDP_TLV_TYPE_COMMON_SESSION_PARAMETERS      0x0500
 #define LDP_TLV_TYPE_LABEL_REQUEST_ID               0x0600
+#define LDP_TLV_TYPE_DUAL_STACK_CAPABILITY          0x0701
 
 #define LDP_TLV_LEN_MIN                             4
 #define LDP_FEC_LEN_MIN                             4
@@ -141,7 +143,13 @@ typedef struct ldp_config_ {
 
     uint16_t id; /* LDP instance identifier */
     uint32_t lsr_id;
-    uint32_t ipv4_transport_address;
+
+    bool prefer_ipv4_transport;
+    bool no_ipv4_transport;
+
+    uint32_t   ipv4_transport_address;
+    ipv6addr_t ipv6_transport_address;
+
     const char *lsr_id_str;
     const char *hostname;
 
@@ -188,7 +196,9 @@ typedef struct ldp_session_ {
     uint16_t max_pdu_len;
     uint16_t keepalive_time;
 
+    bool ipv6; /* True for IPv6 transport session. */
     struct {
+        ipv6addr_t ipv6_address;
         uint32_t ipv4_address;
         uint32_t lsr_id;
         uint16_t label_space_id;
@@ -197,6 +207,7 @@ typedef struct ldp_session_ {
     } local;
 
     struct {
+        ipv6addr_t ipv6_address;
         uint32_t ipv4_address;
         uint32_t lsr_id;
         uint16_t label_space_id;
@@ -234,6 +245,10 @@ typedef struct ldp_session_ {
 typedef struct ldp_adjacency_ {
     bbl_network_interface_s *interface;
     ldp_instance_s *instance;
+
+    bool hello_ipv4;
+    bool hello_ipv6;
+    bool prefer_ipv4_transport;
 
     struct timer_ *hello_timer;
     struct timer_ *hold_timer;

--- a/code/bngblaster/src/ldp/ldp_hello.c
+++ b/code/bngblaster/src/ldp/ldp_hello.c
@@ -9,7 +9,7 @@
 #include "ldp.h"
 
 /**
- * ldp_hello_encode
+ * ldp_hello_ipv4_encode
  *
  * @param interface send interface
  * @param buf send buffer
@@ -18,9 +18,9 @@
  * @return PROTOCOL_SUCCESS on success
  */
 protocol_error_t
-ldp_hello_encode(bbl_network_interface_s *interface, 
-                 uint8_t *buf, uint16_t *len, 
-                 bbl_ethernet_header_s *eth)
+ldp_hello_ipv4_encode(bbl_network_interface_s *interface, 
+                      uint8_t *buf, uint16_t *len, 
+                      bbl_ethernet_header_s *eth)
 {
     protocol_error_t result;
 
@@ -48,20 +48,86 @@ ldp_hello_encode(bbl_network_interface_s *interface,
     ldp.lsr_id = config->lsr_id;
     ldp.hold_time = config->hold_time;
     ldp.ipv4_transport_address = config->ipv4_transport_address;
+    if(adjacency->hello_ipv6) {
+        if(adjacency->prefer_ipv4_transport) {
+            ldp.dual_stack_capability = 4;
+        } else {
+            ldp.dual_stack_capability = 6;
+        }
+    }
     result = encode_ethernet(buf, len, eth);
     if(result == PROTOCOL_SUCCESS) {
-        LOG(DEBUG, "LDP TX hello on interface %s\n", interface->name);
+        LOG(DEBUG, "LDP TX IPv4 hello on interface %s\n", interface->name);
             adjacency->interface->stats.ldp_udp_tx++;
     }
     return result;
+}
+
+protocol_error_t
+ldp_hello_ipv6_encode(bbl_network_interface_s *interface, 
+                      uint8_t *buf, uint16_t *len, 
+                      bbl_ethernet_header_s *eth)
+{
+    protocol_error_t result;
+
+    bbl_ipv6_s ipv6 = {0};
+    bbl_udp_s udp = {0};
+    bbl_ldp_hello_s ldp = {0};
+    uint8_t mac[ETH_ADDR_LEN];
+    
+    ldp_adjacency_s *adjacency = interface->ldp_adjacency;
+    ldp_instance_s  *instance  = adjacency->instance;
+    ldp_config_s    *config    = instance->config;
+
+    /* Build packet ... */
+    ipv6_multicast_mac(ipv6_multicast_all_routers, mac);
+    eth->dst = mac;
+    eth->type = ETH_TYPE_IPV6;
+    eth->next = &ipv6;
+    ipv6.dst = (void*)ipv6_multicast_all_routers;
+    ipv6.src = interface->ip6_ll;
+    ipv6.protocol = IPV6_NEXT_HEADER_UDP;
+    ipv6.next = &udp;
+    ipv6.ttl = 255;
+    udp.src = LDP_PORT;
+    udp.dst = LDP_PORT;
+    udp.protocol = UDP_PROTOCOL_LDP;
+    udp.next = &ldp;
+    ldp.lsr_id = config->lsr_id;
+    ldp.hold_time = config->hold_time;
+    ldp.ipv6_transport_address = &config->ipv6_transport_address;
+    if(adjacency->hello_ipv4) {
+        if(adjacency->prefer_ipv4_transport) {
+            ldp.dual_stack_capability = 4;
+        } else {
+            ldp.dual_stack_capability = 6;
+        }
+    }
+    result = encode_ethernet(buf, len, eth);
+    if(result == PROTOCOL_SUCCESS) {
+        LOG(DEBUG, "LDP TX IPv6 hello on interface %s\n", interface->name);
+            adjacency->interface->stats.ldp_udp_tx++;
+    }
+    return result;
+}
+
+static void
+ldp_hello_send_requests(ldp_adjacency_s *adjacency)
+{
+    bbl_network_interface_s *interface = adjacency->interface;
+    if(adjacency->hello_ipv4) {
+        interface->send_requests |= BBL_IF_SEND_LDP_HELLO_IPV4;
+    }
+    if(adjacency->hello_ipv6) {
+        interface->send_requests |= BBL_IF_SEND_LDP_HELLO_IPV6;
+    }
 }
 
 void
 ldp_hello_job(timer_s *timer)
 {
     ldp_adjacency_s *adjacency = timer->data;
-    bbl_network_interface_s *interface = adjacency->interface;
-    interface->send_requests |= BBL_IF_SEND_LDP_HELLO;
+    ldp_hello_send_requests(adjacency);
 }
 
 /**
@@ -77,6 +143,7 @@ ldp_hello_start(ldp_adjacency_s *adjacency)
     if(!hello_interval) {
         hello_interval = 1;
     }
+    ldp_hello_send_requests(adjacency);
     timer_add_periodic(&g_ctx->timer_root, &adjacency->hello_timer, 
                        "LDP Hello", hello_interval, 0, adjacency, 
                        &ldp_hello_job);
@@ -108,7 +175,7 @@ ldp_hello_restart_hold_timeout(ldp_adjacency_s *adjacency)
 }
 
 /**
- * ldp_hello_rx
+ * ldp_hello_ipv4_rx
  *
  * This function handles all received LDP hello packets.
  *
@@ -118,10 +185,10 @@ ldp_hello_restart_hold_timeout(ldp_adjacency_s *adjacency)
  * @param ldp LDP header of received packet
  */
 void 
-ldp_hello_rx(bbl_network_interface_s *interface, 
-             bbl_ethernet_header_s *eth,
-             bbl_ipv4_s *ipv4,
-             bbl_ldp_hello_s *ldp)
+ldp_hello_ipv4_rx(bbl_network_interface_s *interface, 
+                  bbl_ethernet_header_s *eth,
+                  bbl_ipv4_s *ipv4,
+                  bbl_ldp_hello_s *ldp)
 {
     ldp_adjacency_s *adjacency = interface->ldp_adjacency;
     ldp_instance_s  *instance;
@@ -130,11 +197,11 @@ ldp_hello_rx(bbl_network_interface_s *interface,
     UNUSED(eth);
 
     interface->stats.ldp_udp_rx++;
-    if(!adjacency) {
+    if(!(adjacency && adjacency->hello_ipv4)) {
         return;
     }
 
-    LOG(DEBUG, "LDP RX hello on interface %s\n", interface->name);
+    LOG(DEBUG, "LDP RX IPv4 hello on interface %s\n", interface->name);
 
     instance = adjacency->instance;
     session = instance->sessions;
@@ -157,6 +224,74 @@ ldp_hello_rx(bbl_network_interface_s *interface,
         session = session->next;
     }
 
+
+    if(ldp->dual_stack_capability &&
+       ldp->dual_stack_capability != 4) {
+        return;
+    }
+
     /* Init LDP session. */
-    ldp_session_init(session, adjacency, ipv4, ldp);
+    ldp_session_ipv4_init(session, adjacency, ipv4, ldp);
+    return;
+}
+
+/**
+ * ldp_hello_ipv6_rx
+ *
+ * This function handles all received LDP hello packets.
+ *
+ * @param interface receiving interface
+ * @param eth received ethernet header
+ * @param ipv6 received ipv6 header
+ * @param ldp LDP header of received packet
+ */
+void 
+ldp_hello_ipv6_rx(bbl_network_interface_s *interface, 
+                  bbl_ethernet_header_s *eth,
+                  bbl_ipv6_s *ipv6,
+                  bbl_ldp_hello_s *ldp)
+{
+    ldp_adjacency_s *adjacency = interface->ldp_adjacency;
+    ldp_instance_s  *instance;
+    ldp_session_s   *session;
+
+    UNUSED(eth);
+
+    interface->stats.ldp_udp_rx++;
+    if(!(adjacency && adjacency->hello_ipv6)) {
+        return;
+    }
+
+    LOG(DEBUG, "LDP RX IPv6 hello on interface %s\n", interface->name);
+
+    instance = adjacency->instance;
+    session = instance->sessions;
+
+    if(ldp->hold_time > 0 && ldp->hold_time < adjacency->hold_time) {
+        adjacency->hold_time = ldp->hold_time;
+        ldp_hello_start(adjacency);
+    }
+    ldp_hello_restart_hold_timeout(adjacency);
+
+    while(session) {
+        if(session->peer.lsr_id == ldp->lsr_id && 
+           session->peer.label_space_id == ldp->label_space_id) {
+            if(session->state == LDP_CLOSED) {
+                break;
+            } else {
+                return;
+            }
+        }
+        session = session->next;
+    }
+
+
+    if(ldp->dual_stack_capability &&
+       ldp->dual_stack_capability != 6) {
+        return;
+    }
+
+    /* Init LDP session. */
+    ldp_session_ipv6_init(session, adjacency, ipv6, ldp);
+    return;
 }

--- a/code/bngblaster/src/ldp/ldp_hello.h
+++ b/code/bngblaster/src/ldp/ldp_hello.h
@@ -10,17 +10,28 @@
 #define __BBL_LDP_HELLO_H__
 
 protocol_error_t
-ldp_hello_encode(bbl_network_interface_s *interface, 
-                 uint8_t *buf, uint16_t *len, 
-                 bbl_ethernet_header_s *eth);
+ldp_hello_ipv4_encode(bbl_network_interface_s *interface, 
+                      uint8_t *buf, uint16_t *len, 
+                      bbl_ethernet_header_s *eth);
+
+protocol_error_t
+ldp_hello_ipv6_encode(bbl_network_interface_s *interface, 
+                      uint8_t *buf, uint16_t *len, 
+                      bbl_ethernet_header_s *eth);
 
 void
 ldp_hello_start(ldp_adjacency_s *adjacency);
 
 void
-ldp_hello_rx(bbl_network_interface_s *interface, 
+ldp_hello_ipv4_rx(bbl_network_interface_s *interface, 
              bbl_ethernet_header_s *eth,
              bbl_ipv4_s *ipv4,
              bbl_ldp_hello_s *ldp);
+
+void 
+ldp_hello_ipv6_rx(bbl_network_interface_s *interface, 
+                  bbl_ethernet_header_s *eth,
+                  bbl_ipv6_s *ipv6,
+                  bbl_ldp_hello_s *ldp);
 
 #endif

--- a/code/bngblaster/src/ldp/ldp_interface.c
+++ b/code/bngblaster/src/ldp/ldp_interface.c
@@ -35,7 +35,15 @@ ldp_interface_init(bbl_network_interface_s *interface,
     adjacency->interface = interface;
     adjacency->hold_time = config->hold_time;
     interface->ldp_adjacency = adjacency;
-    
+
+    if(!config->no_ipv4_transport) {
+        adjacency->hello_ipv4 = true;
+        adjacency->prefer_ipv4_transport = config->prefer_ipv4_transport;
+    }
+    if(ipv6_addr_not_zero(&config->ipv6_transport_address)) {
+        adjacency->hello_ipv6 = true;
+    }
+
     ldp_hello_start(adjacency);
     return true;
 }

--- a/code/bngblaster/src/ldp/ldp_session.h
+++ b/code/bngblaster/src/ldp/ldp_session.h
@@ -25,8 +25,12 @@ void
 ldp_session_connect(ldp_session_s *session, time_t delay);
 
 void
-ldp_session_init(ldp_session_s *session, ldp_adjacency_s *adjacency, 
-                 bbl_ipv4_s *ipv4, bbl_ldp_hello_s *ldp);
+ldp_session_ipv4_init(ldp_session_s *session, ldp_adjacency_s *adjacency, 
+                      bbl_ipv4_s *ipv4, bbl_ldp_hello_s *ldp);
+
+void
+ldp_session_ipv6_init(ldp_session_s *session, ldp_adjacency_s *adjacency, 
+                      bbl_ipv6_s *ipv6, bbl_ldp_hello_s *ldp);
 
 void
 ldp_session_close(ldp_session_s *session);

--- a/code/bngblaster/src/lwip/lwipopts.h
+++ b/code/bngblaster/src/lwip/lwipopts.h
@@ -54,8 +54,11 @@ extern unsigned char debug_flags;
 #define LWIP_IPV4                  1
 #define LWIP_IPV6                  1
 
-#define LWIP_IPV6_REASS            0
+#define LWIP_IPV6_FRAG             1
+#define LWIP_IPV6_REASS            1
 #define LWIP_IPV6_AUTOCONFIG       0
+
+#define IPV6_FRAG_COPYHEADER       1
 
 /* ---------- Memory options ---------- */
 /* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
@@ -168,8 +171,8 @@ a lot of data that needs to be copied, this should be set high. */
 
 /* IP reassembly and segmentation.These are orthogonal even
  * if they both deal with IP fragments */
-#define IP_REASSEMBLY           0
-#define IP_FRAG                 0
+#define IP_REASSEMBLY           1
+#define IP_FRAG                 1
 
 /* ---------- ICMP options ---------- */
 #define ICMP_TTL                255

--- a/code/ldpupdate
+++ b/code/ldpupdate
@@ -7,6 +7,7 @@ Christian Giese, December 2022
 Copyright (C) 2020-2023, RtBrick, Inc.
 SPDX-License-Identifier: BSD-3-Clause
 """
+from socket import inet_aton
 import argparse
 import ipaddress
 import logging
@@ -28,7 +29,7 @@ except:
 
 # Monkey patch scapy LDP FecTLVField
 
-def _monkey_i2m(self, pkt, x):
+def _monkey_i2m_fec(self, pkt, x):
     if not x:
         return b""
     if isinstance(x, bytes):
@@ -37,19 +38,54 @@ def _monkey_i2m(self, pkt, x):
     tmp_len = 0
     fec = b""
     for o in x:
-        fec += b"\x02\x00\x01"
-        # mask length
-        fec += struct.pack("!B", o[1])
-        # Prefix
-        l = o[1]+7>>3
-        p = inet_aton(o[0])
-        fec += p[:l]
-        tmp_len += 4+l
+        a = ipaddress.ip_address(o[0])
+        if a.version == 4:
+            fec += b"\x02\x00\x01"
+            # mask length
+            fec += struct.pack("!B", o[1])
+            # Prefix
+            l = o[1]+7>>3
+            p = ipaddress.v4_int_to_packed(int(a))
+            fec += p[:l]
+            tmp_len += 4+l
+        else:
+            fec += b"\x02\x00\x02"
+            # mask length
+            fec += struct.pack("!B", o[1])
+            # Prefix
+            l = o[1]+7>>3
+            p = ipaddress.v6_int_to_packed(int(a))
+            fec += p[:l]
+            tmp_len += 4+l
     s += struct.pack("!H", tmp_len)
     s += fec
     return s
 
-scapy.contrib.ldp.FecTLVField.i2m = _monkey_i2m
+scapy.contrib.ldp.FecTLVField.i2m = _monkey_i2m_fec
+
+
+def _monkey_i2m_address(self, pkt, x):
+    if not x:
+        return b""
+    if isinstance(x, bytes):
+        return x
+    
+    a = ipaddress.ip_address(x[0])
+    if a.version == 4:
+        tmp_len = 2 + len(x) * 4
+        s = b"\x01\x01" + struct.pack("!H", tmp_len) + b"\x00\x01"
+        for o in x:
+            s += inet_aton(o)
+    else:
+        tmp_len = 2 + len(x) * 16
+        s = b"\x01\x01" + struct.pack("!H", tmp_len) + b"\x00\x02"
+        for o in x:
+            a = ipaddress.ip_address(o)
+            s += ipaddress.v6_int_to_packed(int(a))
+    return s
+
+scapy.contrib.ldp.AddressTLVField.i2m = _monkey_i2m_address
+
 
 # ==============================================================
 # DEFINITIONS
@@ -133,15 +169,13 @@ def main():
 
         address = args.address_base
         for _ in range(args.address_num):
+            log.debug("add address %s" % (address))
             addresses.append(address)
             address += 1
 
     prefixes = []
     if args.prefix_base and args.prefix_num > 0:
-        if args.prefix_base.version != 4:
-            log.error("prefix must be IPv4")
-            exit(1)
-        log.info("init %s labeled IPv4 prefixes" % (args.prefix_num))
+        log.info("init %s labeled prefixes" % (args.prefix_num))
 
         prefix = args.prefix_base
         label_index = 0

--- a/code/lwip/src/include/lwip/prot/ip6.h
+++ b/code/lwip/src/include/lwip/prot/ip6.h
@@ -202,7 +202,7 @@ PACK_STRUCT_END
 #define IP6_ROUT_SEG_LEFT(hdr) ((hdr)->_segments_left)
 
 /* Fragment header. */
-#define IP6_FRAG_HLEN    8
+#define IP6_FRAG_HLEN           8
 #define IP6_FRAG_OFFSET_MASK    0xfff8
 #define IP6_FRAG_MORE_FLAG      0x0001
 

--- a/docsrc/sources/configuration/ldp.rst
+++ b/docsrc/sources/configuration/ldp.rst
@@ -28,9 +28,17 @@
    * - `teardown-time`
      - LDP teardown time in seconds
      - 5
+   * - `ipv6-transport-address`
+     - LDP transport IPv6 address
+     - 
    * - `ipv4-transport-address`
-     - LDP transport address
+     - LDP transport IPv6 address
      - `lsr-id`
+   * - `no-ipv4-transport`
+     - Disable/discard IPv4 LDP hello messages
+   * - `prefer-ipv4-transport`
+     - Prefer IPv4 transport even if IPv6 is enabled
+     - `false`
    * - `raw-update-file`
      - LDP RAW update file
      - 
@@ -46,3 +54,7 @@ send keepalive messages at an interval calculated by using the
 effective keepalive time divided by 3. Assuming an effective
 keepalive time of 15 seconds results in a keepalive interval
 of 5 seconds. 
+
+Setting a valid `ipv6-transport-address` enables LDP IPv6 
+hello and transport. According to RFC7552, IPv6 is preferred
+over IPv4 which can be changed with `prefer-ipv4-transport`.

--- a/docsrc/sources/configuration/streams.rst
+++ b/docsrc/sources/configuration/streams.rst
@@ -103,6 +103,9 @@
    * - `ldp-ipv4-lookup-address`
      - Dynamically resolve outer label 
      - 
+   * - `ldp-ipv6-lookup-address`
+     - Dynamically resolve outer label 
+     - 
 
 For L2TP downstream traffic, the IPv4 TOS is applied to the outer IPv4 
 and inner IPv4 header.


### PR DESCRIPTION
# Example

The following example is a modified version of the [LDP example from quickstart guide](https://rtbrick.github.io/bngblaster/quickstart.html#ldp). 

*create LDP update*
```
ldpupdate -l 10.2.3.1 -a fc66::1 -A 10 -p fc66:1::/64 -P 10 -m 10000 -M 100 --log-level debug
ldpupdate  -l 10.2.3.1 -a 10.0.0.0 -A 10 -p 10.1.0.0/24 -P 10 -m 20000 -M 100 --log-level debug --append
```

*start test*
```
sudo bngblaster -C ldp.json -l ldp -S run.sock -P ldp.pcap
```

*ldp.json*
```json
{
    "interfaces": {
        "capture-include-streams": true,
        "network": [
            {
                "interface": "veth1.1",
                "address": "10.0.0.1/24",
                "gateway": "10.0.0.2",
                "ldp-instance-id": 1,
                "address-ipv6": "fc66:1337:7331:ffff::1/64",
                "gateway-ipv6": "fc66:1337:7331:ffff::10"
            },
            {
                "interface": "veth1.2",
                "address": "10.0.0.2/24",
                "gateway": "10.0.0.1",
                "ldp-instance-id": 2,
                "address-ipv6": "fc66:1337:7331:ffff::10/64",
                "gateway-ipv6": "fc66:1337:7331:ffff::1"
            }
        ]
    },
    "ldp": [
        {
            "instance-id": 1,
            "lsr-id": "10.2.3.1",
            "ipv6-transport-address": "fc66:1337:7331:ffff::1",
            "raw-update-file": "out.ldp"
        },
        {
            "instance-id": 2,
            "lsr-id": "10.2.3.2",
            "ipv6-transport-address": "fc66:1337:7331:ffff::10"
        }
    ],
    "streams": [
        {
            "name": "S1",
            "type": "ipv4",
            "direction": "downstream",
            "priority": 128,
            "network-interface": "veth1.2",
            "destination-ipv4-address": "100.0.0.1",
            "ldp-ipv6-lookup-address": "fc66:1:0:2::",
            "pps": 1
        },
        {
            "name": "S2",
            "type": "ipv4",
            "direction": "downstream",
            "priority": 128,
            "network-interface": "veth1.2",
            "destination-ipv4-address": "200.0.0.1",
            "ldp-ipv4-lookup-address": "10.1.1.0",
            "pps": 1
        }
    ]
}
```