### PR TITLE
add stream setup-interval

### DIFF
--- a/code/bngblaster/src/bbl.c
+++ b/code/bngblaster/src/bbl.c
@@ -588,6 +588,7 @@ main(int argc, char *argv[])
             goto CLEANUP;
         }
     }
+    LOG(INFO, "Total PPS of all streams: %.2f\n", g_ctx->total_pps);
 
     /* Setup control job. */
     timer_add_periodic(&g_ctx->timer_root, &g_ctx->control_timer, "Control Timer", 

--- a/code/bngblaster/src/bbl_config.c
+++ b/code/bngblaster/src/bbl_config.c
@@ -2079,7 +2079,7 @@ json_parse_stream(json_t *stream, bbl_stream_config_s *stream_config)
         "destination-ipv6-address", "ipv4-df", "tx-label1",
         "tx-label1-exp", "tx-label1-ttl", "tx-label2",
         "tx-label2-exp", "tx-label2-ttl", "rx-label1",
-        "rx-label2", "nat", "raw-tcp"
+        "rx-label2", "nat", "raw-tcp", "setup-interval"
     };
     if(!schema_validate(stream, "streams", schema, 
     sizeof(schema)/sizeof(schema[0]))) {
@@ -2183,6 +2183,11 @@ json_parse_stream(json_t *stream, bbl_stream_config_s *stream_config)
     JSON_OBJ_GET_NUMBER(stream, value, "stream", "vlan-priority", 0, 7);
     if(value) {
         stream_config->vlan_priority = json_number_value(value);
+    }
+
+    JSON_OBJ_GET_NUMBER(stream, value, "stream", "setup-interval", 0, 900);
+    if(value) {
+        stream_config->setup_interval = json_number_value(value);
     }
 
     value = json_object_get(stream, "pps");

--- a/code/bngblaster/src/bbl_ctx.h
+++ b/code/bngblaster/src/bbl_ctx.h
@@ -136,6 +136,8 @@ typedef struct bbl_ctx_
     endpoint_state_t multicast_endpoint;
     bool zapping;
 
+    double total_pps; /* Sum of all sream PPS */
+
     /* Config options */
     struct {
         bool interface_lock_force;

--- a/code/bngblaster/src/bbl_session.c
+++ b/code/bngblaster/src/bbl_session.c
@@ -1707,7 +1707,7 @@ bbl_session_ctrl_traffic_reset(int fd, uint32_t session_id __attribute__((unused
         }
     }
     dict_itor_free(itor);
-    return bbl_ctrl_status(fd, "ok", 200, NULL);    
+    return bbl_ctrl_status(fd, "ok", 200, NULL);
 }
 
 int

--- a/code/bngblaster/src/bbl_stream.h
+++ b/code/bngblaster/src/bbl_stream.h
@@ -22,6 +22,7 @@ typedef struct bbl_stream_config_
     double pps;
     uint32_t max_packets;
     uint32_t start_delay;
+    uint32_t setup_interval;
 
     uint16_t src_port;
     uint16_t dst_port;
@@ -113,6 +114,7 @@ typedef struct bbl_stream_
 
     bool threaded;
     bool session_traffic;
+    bool setup;
     bool verified;
     bool wait;
     bool stop;

--- a/docsrc/sources/configuration/streams.rst
+++ b/docsrc/sources/configuration/streams.rst
@@ -50,6 +50,13 @@
 |                                | | For example, ``"Gbps": 1``                                     |
 |                                | | which is equal to ``"bps": 1000000000``.                       |
 +--------------------------------+------------------------------------------------------------------+
+| **setup-interval**             | | Set optional setup interval in seconds. If set, sent max 1     |
+|                                | | packet per setup interval until stream becomes verified.       |
+|                                | | After setup is done, the actual rate will be applied.          |
+|                                | | For bidirectional streams (direction both), this requires both |
+|                                | | directions to be verified.                                     |
+|                                | | Default: 0 (disabled) Range: 0 - 900                           |
++--------------------------------+------------------------------------------------------------------+
 | **a10nsp-interface**           | | Select the corresponding A10NSP interface for this stream.     |
 +--------------------------------+------------------------------------------------------------------+
 | **network-interface**          | | Select the corresponding network interface for this stream.    |

--- a/docsrc/sources/nat.rst
+++ b/docsrc/sources/nat.rst
@@ -196,6 +196,33 @@ with the new NAT option to verify NAT TCP streams.
 
 For now, TCP flags (SYN, …) are statically set to SYN but this could be adopted if needed.
 
+Stream Setup interval
+~~~~~~~~~~~~~~~~~~~~~
+
+It is possible to configure an optional stream setup interval in seconds.
+If set, the BNG Blaster will sent max 1 packet per setup interval until the 
+stream becomes verified. After setup is done, the actual rate will be applied. 
+
+For bidirectional streams (direction both), this requires both 
+directions to be verified.    
+
+.. code-block:: json
+
+    {
+        "streams": [
+            {
+                "name": "TCP1",
+                "stream-group-id": 1,
+                "type": "ipv4",
+                "direction": "both",
+                "pps": 1,
+                "setup-interval": 30,
+                "raw-tcp": true,
+                "network-ipv4-address": "10.0.0.1"
+            }
+        ]
+    }
+
 HTTP NAT Extension
 ~~~~~~~~~~~~~~~~~~
 The existing :ref:`HTTP client/server <http>` was also enhanced for NAT usage.


### PR DESCRIPTION
Add new stream configuration option about an optional setup interval in seconds.

If set, the BNG Blaster will sent max 1 packet per setup interval until the 
stream becomes verified. After setup is done, the actual rate will be applied. 

For bidirectional streams (direction both), this requires both 
directions to be verified.    

```json
    {
        "streams": [
            {
                "name": "TCP1",
                "stream-group-id": 1,
                "type": "ipv4",
                "direction": "both",
                "pps": 1,
                "setup-interval": 30,
                "raw-tcp": true,
                "network-ipv4-address": "10.0.0.1"
            }
        ]
    }
```
