### PR TITLE
add support for L2TP client-auth-id

### DIFF
--- a/code/bngblaster/src/bbl_config.c
+++ b/code/bngblaster/src/bbl_config.c
@@ -3824,7 +3824,7 @@ json_parse_config(json_t *root)
             sub = json_array_get(section, i);
 
             const char *schema[] = {
-                "name", "secret", "address",
+                "name", "secret", "address", "client-auth-id",
                 "receive-window-size", "max-retry", "congestion-mode",
                 "data-control-priority", "data-length", "data-offset",
                 "control-tos", "data-control-tos", "hello-interval",
@@ -3847,6 +3847,9 @@ json_parse_config(json_t *root)
             } else {
                 fprintf(stderr, "JSON config error: Missing value for l2tp-server->name\n");
                 return false;
+            }
+            if(json_unpack(sub, "{s:s}", "client-auth-id", &s) == 0) {
+                l2tp_server->client_auth_id = strdup(s);
             }
             if(json_unpack(sub, "{s:s}", "secret", &s) == 0) {
                 l2tp_server->secret = strdup(s);

--- a/code/bngblaster/src/bbl_l2tp.h
+++ b/code/bngblaster/src/bbl_l2tp.h
@@ -80,6 +80,7 @@ typedef struct bbl_l2tp_server_
 
     char *secret;
     char *host_name;
+    char *client_auth_id;
 
     /* Pointer to next L2TP server
      * configuration (simple list). */


### PR DESCRIPTION
Add support to select L2TP server by client-auth-id (SCCRQ hostname). This allows to setup multiple tunnels on the same IP address.  

Example with new `client-auth-id`: 
```json
{
  "l2tp-server": [
    {
      "name": "LNS1S",
      "client-auth-id": "L1S",
      "address": "100.0.0.11",
      "secret": "test1s",
      "receive-window-size": 64,
      "data-control-priority": true,
      "data-control-tos": 224
    },
    {
      "name": "LNS2S",
      "client-auth-id": "L1S",
      "address": "100.0.0.12",
      "secret": "test2s",
      "receive-window-size": 64,
      "data-control-priority": true,
      "data-control-tos": 224
    },
    {
      "name": "LNS1",
      "address": "100.0.0.11",
      "secret": "test1",
      "receive-window-size": 64,
      "data-length": false,
      "data-offset": false,
      "data-control-priority": true,
      "data-control-tos": 224
    },
    {
      "name": "LNS2",
      "address": "100.0.0.12",
      "secret": "test2",
      "receive-window-size": 64,
      "data-length": true,
      "data-offset": false,
      "data-control-priority": true,
      "data-control-tos": 224
    }
  ]
}
```
