### PR TITLE
Lspgen large matrix

### DIFF
--- a/code/lspgen/src/lspgen_ctrl.c
+++ b/code/lspgen/src/lspgen_ctrl.c
@@ -277,8 +277,8 @@ lspgen_ctrl_write_cb(timer_s *timer)
             return;
         }
         json_header = malloc(128);
-        snprintf(json_header, 128, 
-                 "{\n\"command\": \"%s\",\n\"arguments\": {\n\"instance\": %u,\n\"pdu\": [", 
+        snprintf(json_header, 128-1,
+                 "{\n\"command\": \"%s\",\n\"arguments\": {\n\"instance\": %u,\n\"pdu\": [",
                  json_command, ctx->ctrl_instance);
         push_data(&ctx->ctrl_io_buf, (uint8_t *)json_header, strlen(json_header));
         free(json_header);

--- a/code/lspgen/src/lspgen_forest.c
+++ b/code/lspgen/src/lspgen_forest.c
@@ -71,97 +71,112 @@ init_array(int *a, int end)
     }
 }
 
-unsigned int
-convert_matrix_graph(lsdb_ctx_t *ctx, int v, int *adj_matrix)
+void
+connect_node (lsdb_ctx_t *ctx, uint32_t base, int i, int j, uint32_t link_metric)
 {
     struct lsdb_node_ node_template;
     struct lsdb_link_ link_template;
     struct lsdb_node_ *local_node, *remote_node;
     char node_name[32];
-    int i, j, index;
     uint32_t link_index;
-    unsigned int root = 0;
     __uint128_t addr;
 
     memset(&node_template, 0, sizeof(node_template));
     memset(&link_template, 0, sizeof(link_template));
 
+    /*
+     * Add local node.
+     */
+    addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) +
+	base + i - 1;
+    if (ctx->protocol_id == PROTO_ISIS) {
+	lspgen_store_bcd_addr(addr, node_template.key.node_id, 4);
+    } else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
+	lspgen_store_addr(addr, node_template.key.node_id, 4);
+    }
+    snprintf(node_name, sizeof(node_name), "node%u", base+i);
+    node_template.node_name = node_name;
+    local_node = lsdb_add_node(ctx, &node_template);
+
+    /*
+     * Add remote node.
+     */
+    addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) +
+	base + j - 1;
+    if (ctx->protocol_id == PROTO_ISIS) {
+	lspgen_store_bcd_addr(addr, node_template.key.node_id, 4);
+    } else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
+	lspgen_store_addr(addr, node_template.key.node_id, 4);
+    }
+    snprintf(node_name, sizeof(node_name), "node%u", base+j);
+    node_template.node_name = node_name;
+    remote_node = lsdb_add_node(ctx, &node_template);
+
+    for (link_index = 0; link_index < ctx->link_multiplier; link_index++) {
+
+	/*
+	 * Add outgoing link.
+	 */
+	link_template.link_metric = link_metric;
+	addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) +
+	    base + i - 1;
+	if (ctx->protocol_id == PROTO_ISIS) {
+	    lspgen_store_bcd_addr(addr, link_template.key.local_node_id, 4);
+	} else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
+	    lspgen_store_addr(addr, link_template.key.local_node_id, 4);
+	}
+	addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) +
+	    base + j - 1;
+	if (ctx->protocol_id == PROTO_ISIS) {
+	    lspgen_store_bcd_addr(addr, link_template.key.remote_node_id, 4);
+	} else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
+	    lspgen_store_addr(addr, link_template.key.remote_node_id, 4);
+	}
+	lspgen_store_addr(link_index, link_template.key.local_link_id, 4);
+	lsdb_add_link(ctx, local_node, &link_template);
+
+	/*
+	 * Add incoming link.
+	 */
+	addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) +
+	    base + j - 1;
+	if (ctx->protocol_id == PROTO_ISIS) {
+	    lspgen_store_bcd_addr(addr, link_template.key.local_node_id, 4);
+	} else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
+	    lspgen_store_addr(addr, link_template.key.local_node_id, 4);
+	}
+	addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) +
+	    base + i - 1;
+	if (ctx->protocol_id == PROTO_ISIS) {
+	    lspgen_store_bcd_addr(addr, link_template.key.remote_node_id, 4);
+	} else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
+	    lspgen_store_addr(addr, link_template.key.remote_node_id, 4);
+	}
+	lspgen_store_addr(link_index, link_template.key.local_link_id, 4);
+	lsdb_add_link(ctx, remote_node, &link_template);
+    }
+}
+
+uint32_t
+convert_matrix_graph(lsdb_ctx_t *ctx, uint32_t base, int v, int *adj_matrix)
+{
+    int i, j, index;
+    uint32_t root;
+
+    root = 0;
     for (i = 1; i < v; i++) {
         for (j = i + 1; j <= v; j++) {
             index = (i - 1) * v + j - 1;
-            if (adj_matrix[index]) {
-
-            if (!root) {
-                root = i;
-            }
-
-            /*
-             * Add local node.
-             */
-            addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) + i - 1;
-	    if (ctx->protocol_id == PROTO_ISIS) {
-		lspgen_store_bcd_addr(addr, node_template.key.node_id, 4);
-	    } else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
-		lspgen_store_addr(addr, node_template.key.node_id, 4);
+            if (!adj_matrix[index]) {
+		continue;
 	    }
-	    snprintf(node_name, sizeof(node_name), "node%u", i);
-            node_template.node_name = node_name;
-            local_node = lsdb_add_node(ctx, &node_template);
 
-            /*
-             * Add remote node.
-             */
-            addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) + j - 1;
-	    if (ctx->protocol_id == PROTO_ISIS) {
-		lspgen_store_bcd_addr(addr, node_template.key.node_id, 4);
-	    } else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
-		lspgen_store_addr(addr, node_template.key.node_id, 4);
+	    if (!root) {
+		root = i;
 	    }
-	    snprintf(node_name, sizeof(node_name), "node%u", j);
-            node_template.node_name = node_name;
-            remote_node = lsdb_add_node(ctx, &node_template);
 
-	    for (link_index = 0; link_index < ctx->link_multiplier; link_index++) {
-
-		/*
-		 * Add outgoing link.
-		 */
-		link_template.link_metric = weights[adj_matrix[index]];
-		addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) + i - 1;
-		if (ctx->protocol_id == PROTO_ISIS) {
-		    lspgen_store_bcd_addr(addr, link_template.key.local_node_id, 4);
-		} else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
-		    lspgen_store_addr(addr, link_template.key.local_node_id, 4);
-		}
-		addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) + j - 1;
-		if (ctx->protocol_id == PROTO_ISIS) {
-		    lspgen_store_bcd_addr(addr, link_template.key.remote_node_id, 4);
-		} else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
-		    lspgen_store_addr(addr, link_template.key.remote_node_id, 4);
-		}
-		lspgen_store_addr(link_index, link_template.key.local_link_id, 4);
-		lsdb_add_link(ctx, local_node, &link_template);
-
-		/*
-		 * Add incoming link.
-		 */
-		addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) + j - 1;
-		if (ctx->protocol_id == PROTO_ISIS) {
-		    lspgen_store_bcd_addr(addr, link_template.key.local_node_id, 4);
-		} else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
-		    lspgen_store_addr(addr, link_template.key.local_node_id, 4);
-		}
-		addr = lspgen_load_addr((uint8_t*)&ctx->ipv4_node_prefix.address, sizeof(ipv4addr_t)) + i - 1;
-		if (ctx->protocol_id == PROTO_ISIS) {
-		    lspgen_store_bcd_addr(addr, link_template.key.remote_node_id, 4);
-		} else if (ctx->protocol_id == PROTO_OSPF2 || ctx->protocol_id == PROTO_OSPF3) {
-		    lspgen_store_addr(addr, link_template.key.remote_node_id, 4);
-		}
-		lspgen_store_addr(link_index, link_template.key.local_link_id, 4);
-		lsdb_add_link(ctx, remote_node, &link_template);
-            }
-	    }
-        }
+	    connect_node(ctx, base, i, j, weights[adj_matrix[index]]);
+	}
     }
 
     return root;
@@ -184,17 +199,25 @@ convert_matrix_graph(lsdb_ctx_t *ctx, int v, int *adj_matrix)
  *
  * Returns root node index.
  */
-unsigned int
+uint32_t
 lsdb_random_connected_graph(lsdb_ctx_t *ctx, int *tree, int *adj_matrix,
-			    int v, int e, int max_wgt, int weight_flag)
+			    uint32_t base, int v, int e, int max_wgt, int weight_flag)
 {
     int i, j, count, index;
+
+    if (v < 5) {
+	LOG(ERROR, " Minimal node count (5) not reached, %d.\n", v);
+	return 0;
+    }
+
+    LOG(NORMAL, " Generating a subgraph of %d nodes and %d links\n", v, e);
 
     /*
      * Generate a random permutation in the array tree.
      */
     init_array(tree, v);
     permute(tree, v);
+    memset(adj_matrix, 0, v * v * sizeof(int));
 
     /*
      * Next generate a random spanning tree. The algorithm is:
@@ -231,39 +254,53 @@ lsdb_random_connected_graph(lsdb_ctx_t *ctx, int *tree, int *adj_matrix,
         }
     }
 
-    return (convert_matrix_graph(ctx, v, adj_matrix));
+    return convert_matrix_graph(ctx, base, v, adj_matrix);
 }
 
 void
 lsdb_init_graph(lsdb_ctx_t *ctx)
 {
-    int v, e, *adj_matrix, *tree;
+    int remaining_nodes, v, e, max_wgt, *adj_matrix, *tree;
     struct lsdb_node_ node_template;
     struct lsdb_link_ link_template;
     struct lsdb_node_ *node;
-    uint32_t idx, root;
+    uint32_t idx, root, base;
     __uint128_t addr;
 
     srand(ctx->seed);
 
+    base = 0;
     v = ctx->num_nodes;
     e = ctx->num_nodes*2;
+    remaining_nodes = v;
+    max_wgt = sizeof(weights) / sizeof(int) - 1;
 
     LOG(NORMAL, "Generating a graph of %d nodes and %d links\n", v, e);
 
-    if ((adj_matrix = (int *) calloc(v * v, sizeof(int))) == NULL) {
-        LOG(ERROR, "Not enough room for %d nodes %d links  graph\n", v, e);
+    /*
+     * For a large number of nodes do not create a v^2 matrix, but rather
+     * break it down to smaller v=1000 matrixes and connect them.
+     */
+    if (v > 10) {
+	v = 10;
+	e = v*2;
+    }
+
+    if ((adj_matrix = (int *) malloc(v * v * sizeof(int))) == NULL) {
+        LOG(ERROR, "Not enough room for %d nodes %d links graph\n", v, e);
         return;
     }
 
-    if ((tree = (int *) calloc(v, sizeof(int))) == NULL) {
+    if ((tree = (int *) malloc(v * sizeof(int))) == NULL) {
         LOG(ERROR, "Not enough room for %d nodes %d links graph\n", v, e);
         free(adj_matrix);
         return;
     }
 
-    root = lsdb_random_connected_graph(ctx, tree, adj_matrix, v, e,
-				       sizeof(weights) / sizeof(int) - 1, 1);
+    root = lsdb_random_connected_graph(ctx, tree, adj_matrix, 0, v, e, max_wgt, 1);
+    remaining_nodes -= v;
+    base += v;
+
     /*
      * Store root.
      */
@@ -292,6 +329,34 @@ lsdb_init_graph(lsdb_ctx_t *ctx)
 
     LOG(NORMAL, " Root node %s\n", lsdb_format_node(node));
     node->is_root = true;
+
+    /*
+     * Are there outstanding nodes that have not yet been created in the first pass ?
+     */
+    while (remaining_nodes > 0) {
+
+	/* last pass ? */
+	if (remaining_nodes < v) {
+	    v = remaining_nodes;
+	    e = v*2;
+	}
+
+	lsdb_random_connected_graph(ctx, tree, adj_matrix, base, v, e, max_wgt, 1);
+
+	/*
+	 * Connect the first node of this subgraph
+	 * with the last node of the previous subgraph
+	 */
+	connect_node(ctx, base, -1, 0, 99);
+	/*
+	 * Connect the second node of this subgraph
+	 * with the penultimatenode of the previous subgraph
+	 */
+	connect_node(ctx, base, -2, 1, 99);
+
+	remaining_nodes -= v;
+	base += v;
+    }
 
     /*
      * Add connectors to the topology


### PR DESCRIPTION
lspgen is running out of memory if --count gets > 50000 because the random generator allocates a N^2 matrix.
This merge breaks down request node count >> 1000 into N*1000 smaller subgraphs and connect.