### PR TITLE
Add T1 and T2 timer processing to DHCPv4 replies

### DIFF
--- a/code/bngblaster/src/bbl_dhcp.c
+++ b/code/bngblaster/src/bbl_dhcp.c
@@ -254,8 +254,16 @@ bbl_dhcp_rx(bbl_session_s *session, bbl_ethernet_header_s *eth, bbl_dhcp_s *dhcp
                     session->dhcp_domain_name = calloc(1, dhcp->domain_name_len +1);
                     strncpy(session->dhcp_domain_name, dhcp->domain_name, dhcp->domain_name_len);
                 }
-                session->dhcp_t1 = 0.5 * session->dhcp_lease_time; if(!session->dhcp_t1) session->dhcp_t1 = 1;
-                session->dhcp_t2 = 0.875 * session->dhcp_lease_time; if(!session->dhcp_t2) session->dhcp_t2 = 1;
+                if (dhcp->option_t1) {
+                    session->dhcp_t1 = dhcp->t1;
+                } else {
+                    session->dhcp_t1 = 0.5 * session->dhcp_lease_time; if(!session->dhcp_t1) session->dhcp_t1 = 1;
+                }
+                if (dhcp->option_t2) {
+                    session->dhcp_t2 = dhcp->t2;
+                } else {
+                    session->dhcp_t2 = 0.875 * session->dhcp_lease_time; if(!session->dhcp_t2) session->dhcp_t2 = 1;
+                }
 
                 session->send_requests &= ~BBL_SEND_DHCP_REQUEST;
                 if(!session->dhcp_established) {

--- a/code/bngblaster/src/bbl_protocols.c
+++ b/code/bngblaster/src/bbl_protocols.c
@@ -3037,6 +3037,20 @@ decode_dhcp(uint8_t *buf, uint16_t len,
                     return DECODE_ERROR;
                 }
                 break;
+            case DHCP_OPTION_RENEWAL_TIME_VALUE:
+                if(option_len != 4) {
+                    return DECODE_ERROR;
+                }
+                dhcp->t1 = be32toh(*(uint32_t*)buf);
+                dhcp->option_t1 = true;
+                break;
+            case DHCP_OPTION_REBINDING_TIME_VALUE:
+                if(option_len != 4) {
+                    return DECODE_ERROR;
+                }
+                dhcp->t2 = be32toh(*(uint32_t*)buf);
+                dhcp->option_t2 = true;
+                break;
             default:
                 break;
         }

--- a/code/bngblaster/src/bbl_protocols.h
+++ b/code/bngblaster/src/bbl_protocols.h
@@ -941,6 +941,8 @@ typedef struct bbl_dhcp_ {
     uint32_t     dns2;
     uint32_t     router;
     uint16_t     mtu;
+    uint32_t     t1;
+    uint32_t     t2;
     char        *host_name;
     uint8_t      host_name_len;
     char        *domain_name;
@@ -957,6 +959,8 @@ typedef struct bbl_dhcp_ {
     bool         option_mtu;
     bool         option_host_name;
     bool         option_domain_name;
+    bool         option_t1;
+    bool         option_t2;
 
     access_line_s *access_line;
     uint8_t *client_identifier;


### PR DESCRIPTION
- added t1 and t2 uint32_t as well as option_t1 and option_t2 bool to struct bbl_dhcp_
- added dhcp_t1 and dhcp_t2 to struct bbl_session_
- in bbl_dhcp_rx: use T1 and T2 values from the DHCP server if present, otherwise revert to the original behaviour