### PR TITLE
Dev to Main 0.9.13

### DIFF
--- a/code/bngblaster/src/bbl_interface.c
+++ b/code/bngblaster/src/bbl_interface.c
@@ -308,9 +308,10 @@ bbl_interface_ctrl(int fd, uint32_t session_id __attribute__((unused)), json_t *
             io = io->next;
         }
 
-        jobj = json_pack("{ss si ss* ss* si sI sI sI sI }",
+        jobj = json_pack("{ss si si ss* ss* si sI sI sI sI }",
             "name", interface->name,
             "ifindex", interface->ifindex,
+            "ifindex-kernel", interface->kernel_index,
             "type", interface_type_string(interface->type),
             "state", interface_state_string(interface->state),
             "state-transitions", interface->state_transitions,

--- a/code/bngblaster/src/bbl_l2tp.c
+++ b/code/bngblaster/src/bbl_l2tp.c
@@ -1087,6 +1087,11 @@ bbl_l2tp_handler_rx(bbl_network_interface_s *interface,
     l2tp_key_t key = {0};
     void **search = NULL;
 
+    if(!g_ctx->config.l2tp_server) {
+        /* No L2TP server configuration found! */
+        return;
+    }
+
     if(l2tp->type == L2TP_MESSAGE_SCCRQ) {
         bbl_l2tp_sccrq_rx(interface, eth, l2tp);
         return;

--- a/code/bngblaster/src/bbl_stream.c
+++ b/code/bngblaster/src/bbl_stream.c
@@ -1558,7 +1558,14 @@ bbl_stream_io_send_iter(io_handle_s *io, uint64_t now)
             }
             stream = stream->io_next;
         }
-        if(!stream) io_bucket->stream_cur = NULL;
+        if(!stream) {
+            if(io_bucket->stream_cur == io_bucket->stream_head) {
+                /* We can reset bucket base if none of the streams 
+                 * in the bucket is active. */
+                io_bucket->base = 0;
+            }
+            io_bucket->stream_cur = NULL;
+        }
         /* next bucket */
         io_bucket = io_bucket->next;
         if(!io_bucket) io_bucket = io->bucket_head;

--- a/code/bngblaster/src/bbl_tx.c
+++ b/code/bngblaster/src/bbl_tx.c
@@ -1168,10 +1168,14 @@ bbl_tx_encode_packet_dhcp(bbl_session_s *session)
         session->dhcp_request_timestamp.tv_sec = now.tv_sec;
     }
 
-    /* Option 82 ... */
+    /* TR-101 R-124:
+     * The Access Node, when performing the function of a 
+     * Layer 2 DHCP Relay Agent (this is what we emulate here), 
+     * MUST add option-82 with the „circuit-id’ and/or ‘remote-id’ 
+     * sub-options to all DHCP messages sent by the client before 
+     * forwarding to the BNG. */
     if(g_ctx->config.dhcp_access_line && 
-       (session->agent_circuit_id || session->agent_remote_id) && 
-       session->dhcp_state != BBL_DHCP_RELEASE) {
+       (session->agent_circuit_id || session->agent_remote_id)) {
         access_line.aci = session->agent_circuit_id;
         access_line.ari = session->agent_remote_id;
         access_line.aaci = session->access_aggregation_circuit_id;

--- a/code/bngblaster/src/io/io_thread.c
+++ b/code/bngblaster/src/io/io_thread.c
@@ -241,7 +241,7 @@ io_thread_init(io_handle_s *io)
 
     io->thread = thread;
     thread->io = io;
-    io->fanout_id = interface->ifindex+1;
+    io->fanout_id = interface->kernel_index;
     io->fanout_type = PACKET_FANOUT_HASH;
 
     /* Allocate thread scratchpad memory */


### PR DESCRIPTION
RtBrick BNG Blaster Version 0.9.13

#### Fixes

+ fix initial stream traffic burst (#283)
+ fix crash when receiving L2TP packet without L2TP configured
+ fix fanout-id conflict between multiple instances (#294)
+ fix missing access-line in DHCP release packets (TR-101 R-124)

####  Full Changelog

https://github.com/rtbrick/bngblaster/compare/0.9.12..0.9.13