### PR TITLE
ignore egress packets on sockets used for RX

### DIFF
--- a/code/common/src/utils.c
+++ b/code/common/src/utils.c
@@ -8,6 +8,27 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "utils.h"
+#include <sys/utsname.h>
+
+/*
+ * Get linux kernel version major,minor and patch number.
+ */
+kernel_version_s get_kernel_version(void)
+{
+    struct utsname buffer;
+    kernel_version_s kv = {0, 0, 0};
+
+    if (uname(&buffer) != 0) {
+        return kv;  // returns zeros on failure
+    }
+
+    sscanf(buffer.release, "%u.%u.%u",
+           &kv.major,
+           &kv.minor,
+           &kv.patch);
+
+    return kv;
+}
 
 /*
  * Simple big endian reader.

--- a/code/common/src/utils.h
+++ b/code/common/src/utils.h
@@ -11,6 +11,15 @@
 #define __COMMON_UTILS_H__
 #include "common.h"
 
+typedef struct kernel_version_
+{
+    uint32_t major;
+    uint32_t minor;
+    uint32_t patch;
+} kernel_version_s;
+
+kernel_version_s get_kernel_version(void);
+
 uint64_t read_be_uint(uint8_t *data, size_t length);
 bool write_be_uint(uint8_t *data, size_t length, uint64_t value);
 bool inc_be_uint(uint8_t *data, size_t length);


### PR DESCRIPTION
Fix #357 #206 
Note this breaks compatibility with linux version older than 4.20.