### PR TITLE
avoid crash when rescheduling timers from callback (#356)

### DIFF
--- a/code/common/src/timer.h
+++ b/code/common/src/timer.h
@@ -61,6 +61,8 @@ typedef struct timer_
     bool delete; /* timer has been deleted */
     bool on_change_list; /* node is on change list */
     char name[32];
+    time_t sec;
+    long nsec;
 } timer_s;
 
 /* Public API */


### PR DESCRIPTION
Previously, invoking timer_add from within a timer's callback triggered a segmentation fault if the timer's original bucket became empty and was freed during iteration.