### PR TITLE
Anzimber feature/auto cpu numa topology introspection

### DIFF
--- a/code/bngblaster-cli
+++ b/code/bngblaster-cli
@@ -32,6 +32,8 @@ for interactive communication with the BNG Blaster.
 
 Examples:
     {c} run.sock session-info session-id 1
+    {c} run.sock interface-topology
+    {c} run.sock interface-topology interface eth0
     {c} run.sock igmp-join session-id 1 group 239.0.0.1 source1 1.1.1.1 source2 2.2.2.2 source3 3.3.3.3
     {c} run.sock igmp-info session-id 1
     {c} run.sock l2tp-csurq tunnel-id 1 sessions [1,2]
@@ -99,6 +101,22 @@ def main():
     if sys.argv[2] == "commands":
         for cmd in data["commands"]: 
             print("%s %s" % (cmd["command"], str(cmd["arguments"]).replace("', '", "|").replace("'", "")))
+    elif sys.argv[2] == "interface-topology":
+        for interface in data["interfaces"]:
+            print("interface: %s" % interface["name"])
+            print("  io-mode: %s" % interface["io-mode"])
+            print("  numa-node: %s" % interface["numa-node"])
+            print("  local-cpuset: %s" % interface["local-cpuset"])
+            print("  rx-auto-cpuset: %s" % interface["rx-auto-cpuset"])
+            for thread in interface["rx-threads"]:
+                print("  rx-thread id=%s cpu=%s source=%s queue=%s active=%s stopped=%s" % (
+                    thread["id"], thread["selected-cpu"], thread["cpu-source"],
+                    thread.get("queue", "-"), thread["thread-active"], thread["thread-stopped"]))
+            print("  tx-auto-cpuset: %s" % interface["tx-auto-cpuset"])
+            for thread in interface["tx-threads"]:
+                print("  tx-thread id=%s cpu=%s source=%s queue=%s active=%s stopped=%s" % (
+                    thread["id"], thread["selected-cpu"], thread["cpu-source"],
+                    thread.get("queue", "-"), thread["thread-active"], thread["thread-stopped"]))
     else:
         print(json.dumps(data, indent=4))
 

--- a/code/bngblaster-cli
+++ b/code/bngblaster-cli
@@ -116,7 +116,7 @@ def main():
             for thread in interface["tx-threads"]:
                 print("  tx-thread id=%s cpu=%s source=%s queue=%s active=%s stopped=%s" % (
                     thread["id"], thread["selected-cpu"], thread["cpu-source"],
-                    thread.get("queue", "-"), thread["thread-active"], thread["thread-stopped"]))
+                    thread.get("queue", "N/A"), thread["thread-active"], thread["thread-stopped"]))
     else:
         print(json.dumps(data, indent=4))
 

--- a/code/bngblaster-cli
+++ b/code/bngblaster-cli
@@ -111,7 +111,7 @@ def main():
             for thread in interface["rx-threads"]:
                 print("  rx-thread id=%s cpu=%s source=%s queue=%s active=%s stopped=%s" % (
                     thread["id"], thread["selected-cpu"], thread["cpu-source"],
-                    thread.get("queue", "-"), thread["thread-active"], thread["thread-stopped"]))
+                    thread.get("queue", "N/A"), thread["thread-active"], thread["thread-stopped"]))
             print("  tx-auto-cpuset: %s" % interface["tx-auto-cpuset"])
             for thread in interface["tx-threads"]:
                 print("  tx-thread id=%s cpu=%s source=%s queue=%s active=%s stopped=%s" % (

--- a/code/bngblaster/src/bbl_config.c
+++ b/code/bngblaster/src/bbl_config.c
@@ -624,6 +624,8 @@ link_add(char *interface_name)
     link_config->rx_interval = g_ctx->config.rx_interval;
     link_config->tx_threads = g_ctx->config.tx_threads;
     link_config->rx_threads = g_ctx->config.rx_threads;
+    link_config->tx_auto_cpuset = g_ctx->config.tx_auto_cpuset;
+    link_config->rx_auto_cpuset = g_ctx->config.rx_auto_cpuset;
     link_config->next = g_ctx->config.link_config;
     g_ctx->config.link_config = link_config;
 }
@@ -642,6 +644,7 @@ json_parse_link(json_t *link, bbl_link_config_s *link_config)
         "qdisc-bypass", 
         "tx-interval","rx-interval", 
         "tx-threads", "rx-threads",
+        "tx-auto-cpuset", "rx-auto-cpuset",
         "rx-cpuset", "tx-cpuset", 
         "lag-interface", "lacp-priority"
     };
@@ -750,6 +753,18 @@ json_parse_link(json_t *link, bbl_link_config_s *link_config)
         link_config->rx_threads = json_number_value(value);
     } else {
         link_config->rx_threads = g_ctx->config.rx_threads;
+    }
+    JSON_OBJ_GET_BOOL(link, value, "links", "rx-auto-cpuset");
+    if(value) {
+        link_config->rx_auto_cpuset = json_boolean_value(value);
+    } else {
+        link_config->rx_auto_cpuset = g_ctx->config.rx_auto_cpuset;
+    }
+    JSON_OBJ_GET_BOOL(link, value, "links", "tx-auto-cpuset");
+    if(value) {
+        link_config->tx_auto_cpuset = json_boolean_value(value);
+    } else {
+        link_config->tx_auto_cpuset = g_ctx->config.tx_auto_cpuset;
     }
 
     value = json_object_get(link, "rx-cpuset");
@@ -4162,7 +4177,8 @@ json_parse_config(json_t *root)
         const char *schema[] = {
             "io-mode", "io-slots", "io-burst", "qdisc-bypass", "jumbo-frames",
             "tx-interval", "rx-interval", "tx-threads", "tun-name",
-            "rx-threads", "capture-include-streams", "mac-modifier",
+            "rx-threads", "tx-auto-cpuset", "rx-auto-cpuset",
+            "capture-include-streams", "mac-modifier",
             "lag", "network", "access", "a10nsp", "links", "a10nsp-dynamic"
         };
         if(!schema_validate(section, "interfaces", schema, 
@@ -4224,6 +4240,14 @@ json_parse_config(json_t *root)
         JSON_OBJ_GET_NUMBER(section, value, "interfaces", "rx-threads", 0, 255);
         if(value) {
             g_ctx->config.rx_threads = json_number_value(value);
+        }
+        JSON_OBJ_GET_BOOL(section, value, "interfaces", "tx-auto-cpuset");
+        if(value) {
+            g_ctx->config.tx_auto_cpuset = json_boolean_value(value);
+        }
+        JSON_OBJ_GET_BOOL(section, value, "interfaces", "rx-auto-cpuset");
+        if(value) {
+            g_ctx->config.rx_auto_cpuset = json_boolean_value(value);
         }
         JSON_OBJ_GET_BOOL(section, value, "interfaces", "capture-include-streams");
         if(value) {

--- a/code/bngblaster/src/bbl_config.h
+++ b/code/bngblaster/src/bbl_config.h
@@ -208,6 +208,8 @@ typedef struct bbl_link_config_
 
     uint8_t tx_threads;
     uint8_t rx_threads;
+    bool tx_auto_cpuset;
+    bool rx_auto_cpuset;
 
     uint16_t *tx_cpuset;
     uint16_t  tx_cpuset_count;

--- a/code/bngblaster/src/bbl_ctrl.c
+++ b/code/bngblaster/src/bbl_ctrl.c
@@ -309,6 +309,7 @@ static const struct action actions[] = {
     {"session-traffic", bbl_session_ctrl_traffic_stats, schema_no_args, true},
     {"session-traffic-reset", bbl_session_ctrl_traffic_reset, schema_session_group_id, false},
     {"interfaces", bbl_interface_ctrl, schema_no_args, true},
+    {"interface-topology", bbl_interface_ctrl_topology, schema_interface, true},
     {"access-interfaces", bbl_access_ctrl_interfaces, schema_no_args, true},
     {"network-interfaces", bbl_network_ctrl_interfaces, schema_no_args, true},
     {"a10nsp-interfaces", bbl_a10nsp_ctrl_interfaces, schema_no_args, true},

--- a/code/bngblaster/src/bbl_ctx.h
+++ b/code/bngblaster/src/bbl_ctx.h
@@ -162,6 +162,8 @@ typedef struct bbl_ctx_
 
         uint8_t tx_threads;
         uint8_t rx_threads;
+        bool tx_auto_cpuset;
+        bool rx_auto_cpuset;
 
         char *tun_name;
         char *json_report_filename;

--- a/code/bngblaster/src/bbl_interface.c
+++ b/code/bngblaster/src/bbl_interface.c
@@ -9,6 +9,59 @@
 #include "bbl.h"
 #include <sys/stat.h>
 
+static json_t *
+bbl_interface_ctrl_topology_cpuset(uint16_t *cpuset, uint16_t count)
+{
+    uint16_t i;
+    json_t *jarray = json_array();
+
+    if(!jarray) {
+        return NULL;
+    }
+    for(i = 0; i < count; i++) {
+        json_array_append_new(jarray, json_integer(cpuset[i]));
+    }
+    return jarray;
+}
+
+static json_t *
+bbl_interface_ctrl_topology_threads(io_handle_s *io, bool auto_cpuset, bool manual_cpuset)
+{
+    json_t *jarray = json_array();
+    json_t *jobj;
+    const char *source;
+
+    if(!jarray) {
+        return NULL;
+    }
+    while(io) {
+        if(io->thread) {
+            source = "none";
+            if(manual_cpuset) {
+                source = "manual";
+            } else if(auto_cpuset) {
+                source = "auto";
+            }
+            jobj = json_pack("{si ss sb sb si}",
+                             "id", io->id,
+                             "cpu-source", source,
+                             "thread-active", io->thread->active,
+                             "thread-stopped", io->thread->stopped,
+                             "selected-cpu", io->thread->selected_cpu);
+#ifdef BNGBLASTER_DPDK
+            if(jobj && io->mode == IO_MODE_DPDK) {
+                json_object_set_new(jobj, "queue", json_integer(io->queue));
+            }
+#endif
+            if(jobj) {
+                json_array_append_new(jarray, jobj);
+            }
+        }
+        io = io->next;
+    }
+    return jarray;
+}
+
 const char *
 interface_type_string(interface_type_t type)
 {
@@ -29,6 +82,19 @@ interface_state_string(interface_state_t state)
         case INTERFACE_DOWN: return "Down";
         case INTERFACE_STANDBY: return "Standby";
         default: return "N/A";
+    }
+}
+
+static const char *
+interface_io_mode_string(io_mode_t mode)
+{
+    switch(mode) {
+        case IO_MODE_PACKET_MMAP_RAW: return "packet_mmap_raw";
+        case IO_MODE_PACKET_MMAP: return "packet_mmap";
+        case IO_MODE_RAW: return "raw";
+        case IO_MODE_DPDK: return "dpdk";
+        case IO_MODE_AF_XDP: return "af_xdp";
+        default: return "disabled";
     }
 }
 
@@ -337,6 +403,67 @@ bbl_interface_ctrl(int fd, uint32_t session_id __attribute__((unused)), json_t *
 
     if(root) {
         result = json_dumpfd(root, fd, 0);
+        json_decref(root);
+    } else {
+        result = bbl_ctrl_status(fd, "error", 500, "internal error");
+    }
+    return result;
+}
+
+int
+bbl_interface_ctrl_topology(int fd, uint32_t session_id __attribute__((unused)), json_t *arguments)
+{
+    int result = 0;
+    const char *name = NULL;
+    bbl_interface_s *interface;
+    json_t *root;
+    json_t *jobj;
+    json_t *jobj_array = json_array();
+    json_t *jcpuset;
+    json_t *jrx_threads;
+    json_t *jtx_threads;
+
+    if(arguments) {
+        json_unpack(arguments, "{s?s}", "interface", &name);
+    }
+
+    CIRCLEQ_FOREACH(interface, &g_ctx->interface_qhead, interface_qnode) {
+        if(name && strcmp(name, interface->name) != 0) {
+            continue;
+        }
+
+        jcpuset = bbl_interface_ctrl_topology_cpuset(interface->local_cpuset, interface->local_cpuset_count);
+        jrx_threads = bbl_interface_ctrl_topology_threads(interface->io.rx,
+                                                          interface->config->rx_auto_cpuset,
+                                                          interface->config->rx_cpuset_count != 0);
+        jtx_threads = bbl_interface_ctrl_topology_threads(interface->io.tx,
+                                                          interface->config->tx_auto_cpuset,
+                                                          interface->config->tx_cpuset_count != 0);
+        jobj = json_pack("{ss ss si so so so sb sb}",
+                         "name", interface->name,
+                         "io-mode", interface_io_mode_string(interface->config->io_mode),
+                         "numa-node", interface->numa_node,
+                         "local-cpuset", jcpuset,
+                         "rx-threads", jrx_threads,
+                         "tx-threads", jtx_threads,
+                         "rx-auto-cpuset", interface->config->rx_auto_cpuset,
+                         "tx-auto-cpuset", interface->config->tx_auto_cpuset);
+        if(jobj) {
+            json_array_append_new(jobj_array, jobj);
+        }
+    }
+
+    if(name && json_array_size(jobj_array) == 0) {
+        json_decref(jobj_array);
+        return bbl_ctrl_status(fd, "warning", 404, "interface not found");
+    }
+
+    root = json_pack("{ss si so}",
+                     "status", "ok",
+                     "code", 200,
+                     "interfaces", jobj_array);
+    if(root) {
+        result = json_dumpfd(root, fd, JSON_INDENT(4));
         json_decref(root);
     } else {
         result = bbl_ctrl_status(fd, "error", 500, "internal error");

--- a/code/bngblaster/src/bbl_interface.h
+++ b/code/bngblaster/src/bbl_interface.h
@@ -19,6 +19,9 @@ typedef struct bbl_interface_
     uint32_t ifindex; /* internal interface index */
     uint32_t kernel_index; /* kernel interface index  */
     uint16_t port_id; /* DPDK port identifier */
+    int numa_node; /* local NUMA node if known */
+    uint16_t *local_cpuset; /* auto-discovered local CPU list */
+    uint16_t local_cpuset_count;
 
     bbl_link_config_s *config;
 
@@ -67,5 +70,8 @@ bbl_interface_ctrl_disable(int fd, uint32_t session_id __attribute__((unused)), 
 
 int
 bbl_interface_ctrl(int fd, uint32_t session_id __attribute__((unused)), json_t *arguments __attribute__((unused)));
+
+int
+bbl_interface_ctrl_topology(int fd, uint32_t session_id __attribute__((unused)), json_t *arguments);
 
 #endif

--- a/code/bngblaster/src/io/io_def.h
+++ b/code/bngblaster/src/io/io_def.h
@@ -118,6 +118,7 @@ typedef struct io_thread_ {
     volatile bool stopped;
     
     bool set_cpu_affinity;
+    int selected_cpu;
     cpu_set_t cpuset;
 
     io_thread_cb_fn setup_fn;

--- a/code/bngblaster/src/io/io_dpdk.c
+++ b/code/bngblaster/src/io/io_dpdk.c
@@ -566,6 +566,15 @@ io_dpdk_interface_init(bbl_interface_s *interface)
         return false;
     }
 
+    if((config->rx_auto_cpuset && !config->rx_cpuset_count) ||
+       (config->tx_auto_cpuset && !config->tx_cpuset_count)) {
+        if(!io_interface_init_topology(interface, rte_eth_dev_socket_id(port_id))) {
+            LOG(ERROR, "DPDK: failed to discover local CPU topology for interface %s (%u)\n",
+                interface->name, port_id);
+            return false;
+        }
+    }
+
     /* Get MAC address */
     if(*(uint32_t*)config->mac) {
         memcpy(interface->mac, config->mac, ETH_ADDR_LEN);

--- a/code/bngblaster/src/io/io_interface.c
+++ b/code/bngblaster/src/io/io_interface.c
@@ -9,6 +9,246 @@
 #include "io.h"
 #include "ifaddrs.h"
 
+#define BBL_CPU_ID_MAX 4096
+
+static bool
+read_first_line(const char *path, char *buf, size_t len)
+{
+    FILE *fp;
+
+    fp = fopen(path, "r");
+    if(!fp) {
+        return false;
+    }
+    if(!fgets(buf, len, fp)) {
+        fclose(fp);
+        return false;
+    }
+    fclose(fp);
+    return true;
+}
+
+static bool
+read_cpu_topology_int(uint16_t cpu, const char *leaf, int *value)
+{
+    char path[256];
+    char buf[64];
+
+    snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%u/topology/%s", cpu, leaf);
+    if(!read_first_line(path, buf, sizeof(buf))) {
+        return false;
+    }
+    *value = atoi(buf);
+    return true;
+}
+
+static bool
+parse_cpuset(char *input, uint16_t **cpuset, uint16_t *count)
+{
+    long max_cpu;
+    char *buf;
+    char *token;
+    char *saveptr = NULL;
+    uint16_t *list;
+    uint16_t list_count = 0;
+    unsigned int first;
+    unsigned int last;
+    unsigned int cpu;
+
+    max_cpu = sysconf(_SC_NPROCESSORS_CONF);
+    if(max_cpu <= 0) {
+        max_cpu = 1024;
+    }
+
+    buf = strdup(input);
+    list = calloc(max_cpu, sizeof(uint16_t));
+    if(!(buf && list)) {
+        free(buf);
+        free(list);
+        return false;
+    }
+
+    token = strtok_r(buf, ", \t\r\n", &saveptr);
+    while(token) {
+        if(sscanf(token, "%u-%u", &first, &last) == 2) {
+            if(last < first) {
+                free(buf);
+                free(list);
+                return false;
+            }
+        } else if(sscanf(token, "%u", &first) == 1) {
+            last = first;
+        } else {
+            free(buf);
+            free(list);
+            return false;
+        }
+
+        for(cpu = first; cpu <= last; cpu++) {
+            if(list_count >= max_cpu) {
+                free(buf);
+                free(list);
+                return false;
+            }
+            list[list_count++] = cpu;
+        }
+        token = strtok_r(NULL, ", \t\r\n", &saveptr);
+    }
+
+    free(buf);
+    if(!list_count) {
+        free(list);
+        return false;
+    }
+
+    *cpuset = list;
+    *count = list_count;
+    return true;
+}
+
+static bool
+cpu_in_list(const uint16_t *cpuset, uint16_t count, uint16_t cpu)
+{
+    uint16_t i;
+    for(i = 0; i < count; i++) {
+        if(cpuset[i] == cpu) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool
+append_cpu(uint16_t *cpuset, uint16_t *count, uint16_t max, uint16_t cpu)
+{
+    if(*count >= max || cpu_in_list(cpuset, *count, cpu)) {
+        return false;
+    }
+    cpuset[(*count)++] = cpu;
+    return true;
+}
+
+static void
+order_cpuset_physical_first(uint16_t **cpuset, uint16_t count)
+{
+    uint16_t *ordered;
+    uint16_t ordered_count = 0;
+    uint16_t i;
+    uint16_t j;
+    int package_id;
+    int core_id;
+    int seen_package[BBL_CPU_ID_MAX];
+    int seen_core[BBL_CPU_ID_MAX];
+    uint16_t seen_count = 0;
+    bool sibling_added;
+
+    if(count < 2) {
+        return;
+    }
+
+    ordered = calloc(count, sizeof(uint16_t));
+    if(!ordered) {
+        return;
+    }
+
+    for(i = 0; i < count; i++) {
+        if(!read_cpu_topology_int((*cpuset)[i], "physical_package_id", &package_id) ||
+           !read_cpu_topology_int((*cpuset)[i], "core_id", &core_id)) {
+            continue;
+        }
+        sibling_added = false;
+        for(j = 0; j < seen_count; j++) {
+            if(seen_package[j] == package_id && seen_core[j] == core_id) {
+                sibling_added = true;
+                break;
+            }
+        }
+        if(!sibling_added) {
+            append_cpu(ordered, &ordered_count, count, (*cpuset)[i]);
+            if(seen_count < BBL_CPU_ID_MAX) {
+                seen_package[seen_count] = package_id;
+                seen_core[seen_count] = core_id;
+                seen_count++;
+            }
+        }
+    }
+
+    for(i = 0; i < count; i++) {
+        append_cpu(ordered, &ordered_count, count, (*cpuset)[i]);
+    }
+
+    if(ordered_count == count) {
+        memcpy(*cpuset, ordered, count * sizeof(uint16_t));
+    }
+    free(ordered);
+}
+
+bool
+io_interface_init_topology(bbl_interface_s *interface, int numa_node_hint)
+{
+    char path[256];
+    char buf[256];
+    uint16_t *cpuset = NULL;
+    uint16_t count = 0;
+    int numa_node = -1;
+    bool use_online = false;
+
+    if(numa_node_hint >= -1) {
+        numa_node = numa_node_hint;
+    }
+
+    if(interface->config->io_mode == IO_MODE_DPDK) {
+        snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/local_cpulist", interface->name);
+    } else {
+        snprintf(path, sizeof(path), "/sys/class/net/%s/device/local_cpulist", interface->name);
+    }
+    if(read_first_line(path, buf, sizeof(buf)) && parse_cpuset(buf, &cpuset, &count)) {
+        goto SUCCESS;
+    }
+
+    if(numa_node < 0) {
+        if(interface->config->io_mode == IO_MODE_DPDK) {
+            snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/numa_node", interface->name);
+        } else {
+            snprintf(path, sizeof(path), "/sys/class/net/%s/device/numa_node", interface->name);
+        }
+        if(read_first_line(path, buf, sizeof(buf))) {
+            numa_node = atoi(buf);
+        }
+    }
+
+    if(numa_node >= 0) {
+        snprintf(path, sizeof(path), "/sys/devices/system/node/node%d/cpulist", numa_node);
+        if(read_first_line(path, buf, sizeof(buf)) && parse_cpuset(buf, &cpuset, &count)) {
+            goto SUCCESS;
+        }
+    }
+
+    use_online = true;
+    if(read_first_line("/sys/devices/system/cpu/online", buf, sizeof(buf)) &&
+       parse_cpuset(buf, &cpuset, &count)) {
+        goto SUCCESS;
+    }
+    return false;
+
+SUCCESS:
+    order_cpuset_physical_first(&cpuset, count);
+    interface->numa_node = numa_node;
+    interface->local_cpuset = cpuset;
+    interface->local_cpuset_count = count;
+    if(use_online) {
+        LOG(INFO, "Auto CPU placement for interface %s uses system online CPUs (%u entries)\n",
+            interface->name, count);
+    } else if(numa_node >= 0) {
+        LOG(INFO, "Auto CPU placement for interface %s uses NUMA node %d (%u CPUs)\n",
+            interface->name, numa_node, count);
+    } else {
+        LOG(INFO, "Auto CPU placement for interface %s uses local CPU list (%u entries)\n",
+            interface->name, count);
+    }
+    return true;
+}
+
 static bool
 set_kernel_info(bbl_interface_s *interface)
 {
@@ -218,6 +458,13 @@ io_interface_init(bbl_interface_s *interface)
         address_warning(interface);
         if(!set_kernel_info(interface)) {
             return false;
+        }
+        if((config->rx_auto_cpuset && !config->rx_cpuset_count) ||
+           (config->tx_auto_cpuset && !config->tx_cpuset_count)) {
+            if(!io_interface_init_topology(interface, -2)) {
+                LOG(ERROR, "Failed to discover local CPU topology for interface %s\n", interface->name);
+                return false;
+            }
         }
         if(!set_promisc(interface)) {
             return false;

--- a/code/bngblaster/src/io/io_interface.c
+++ b/code/bngblaster/src/io/io_interface.c
@@ -191,19 +191,12 @@ io_interface_init_topology(bbl_interface_s *interface, int numa_node_hint)
     uint16_t *cpuset = NULL;
     uint16_t count = 0;
     int numa_node = -1;
+    bool use_local = false;
+    bool use_numa = false;
     bool use_online = false;
 
     if(numa_node_hint >= -1) {
         numa_node = numa_node_hint;
-    }
-
-    if(interface->config->io_mode == IO_MODE_DPDK) {
-        snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/local_cpulist", interface->name);
-    } else {
-        snprintf(path, sizeof(path), "/sys/class/net/%s/device/local_cpulist", interface->name);
-    }
-    if(read_first_line(path, buf, sizeof(buf)) && parse_cpuset(buf, &cpuset, &count)) {
-        goto SUCCESS;
     }
 
     if(numa_node < 0) {
@@ -217,9 +210,20 @@ io_interface_init_topology(bbl_interface_s *interface, int numa_node_hint)
         }
     }
 
+    if(interface->config->io_mode == IO_MODE_DPDK) {
+        snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/local_cpulist", interface->name);
+    } else {
+        snprintf(path, sizeof(path), "/sys/class/net/%s/device/local_cpulist", interface->name);
+    }
+    if(read_first_line(path, buf, sizeof(buf)) && parse_cpuset(buf, &cpuset, &count)) {
+        use_local = true;
+        goto SUCCESS;
+    }
+
     if(numa_node >= 0) {
         snprintf(path, sizeof(path), "/sys/devices/system/node/node%d/cpulist", numa_node);
         if(read_first_line(path, buf, sizeof(buf)) && parse_cpuset(buf, &cpuset, &count)) {
+            use_numa = true;
             goto SUCCESS;
         }
     }
@@ -239,12 +243,18 @@ SUCCESS:
     if(use_online) {
         LOG(INFO, "Auto CPU placement for interface %s uses system online CPUs (%u entries)\n",
             interface->name, count);
-    } else if(numa_node >= 0) {
-        LOG(INFO, "Auto CPU placement for interface %s uses NUMA node %d (%u CPUs)\n",
+    } else if(use_local && numa_node >= 0) {
+        LOG(INFO, "Auto CPU placement for interface %s uses local CPU list on NUMA node %d (%u entries)\n",
             interface->name, numa_node, count);
-    } else {
+    } else if(use_local) {
         LOG(INFO, "Auto CPU placement for interface %s uses local CPU list (%u entries)\n",
             interface->name, count);
+    } else if(use_numa) {
+        LOG(INFO, "Auto CPU placement for interface %s uses NUMA node %d (%u CPUs)\n",
+            interface->name, numa_node, count);
+    } else if(numa_node >= 0) {
+        LOG(INFO, "Auto CPU placement for interface %s is associated with NUMA node %d (%u CPUs)\n",
+            interface->name, numa_node, count);
     }
     return true;
 }

--- a/code/bngblaster/src/io/io_interface.c
+++ b/code/bngblaster/src/io/io_interface.c
@@ -9,8 +9,6 @@
 #include "io.h"
 #include "ifaddrs.h"
 
-#define BBL_CPU_ID_MAX 4096
-
 static bool
 read_first_line(const char *path, char *buf, size_t len)
 {
@@ -57,7 +55,7 @@ parse_cpuset(char *input, uint16_t **cpuset, uint16_t *count)
 
     max_cpu = sysconf(_SC_NPROCESSORS_CONF);
     if(max_cpu <= 0) {
-        max_cpu = 1024;
+        max_cpu = CPU_SETSIZE;
     }
 
     buf = strdup(input);
@@ -131,14 +129,14 @@ append_cpu(uint16_t *cpuset, uint16_t *count, uint16_t max, uint16_t cpu)
 static void
 order_cpuset_physical_first(uint16_t **cpuset, uint16_t count)
 {
-    uint16_t *ordered;
+    uint16_t *ordered = NULL;;
     uint16_t ordered_count = 0;
     uint16_t i;
     uint16_t j;
     int package_id;
     int core_id;
-    int seen_package[BBL_CPU_ID_MAX];
-    int seen_core[BBL_CPU_ID_MAX];
+    int *seen_package = NULL;
+    int *seen_core = NULL;
     uint16_t seen_count = 0;
     bool sibling_added;
 
@@ -147,7 +145,12 @@ order_cpuset_physical_first(uint16_t **cpuset, uint16_t count)
     }
 
     ordered = calloc(count, sizeof(uint16_t));
-    if(!ordered) {
+    seen_package = calloc(CPU_SETSIZE, sizeof(int));
+    seen_core = calloc(CPU_SETSIZE, sizeof(int));
+    if(!ordered || !seen_package || !seen_core) {
+        free(ordered);
+        free(seen_package);
+        free(seen_core);
         return;
     }
 
@@ -165,7 +168,7 @@ order_cpuset_physical_first(uint16_t **cpuset, uint16_t count)
         }
         if(!sibling_added) {
             append_cpu(ordered, &ordered_count, count, (*cpuset)[i]);
-            if(seen_count < BBL_CPU_ID_MAX) {
+            if(seen_count < CPU_SETSIZE) {
                 seen_package[seen_count] = package_id;
                 seen_core[seen_count] = core_id;
                 seen_count++;
@@ -181,13 +184,15 @@ order_cpuset_physical_first(uint16_t **cpuset, uint16_t count)
         memcpy(*cpuset, ordered, count * sizeof(uint16_t));
     }
     free(ordered);
+    free(seen_package);
+    free(seen_core);
 }
 
 bool
 io_interface_init_topology(bbl_interface_s *interface, int numa_node_hint)
 {
     char path[256];
-    char buf[256];
+    char buf[4096];
     uint16_t *cpuset = NULL;
     uint16_t count = 0;
     int numa_node = -1;

--- a/code/bngblaster/src/io/io_interface.h
+++ b/code/bngblaster/src/io/io_interface.h
@@ -12,4 +12,7 @@
 bool
 io_interface_init(bbl_interface_s *interface);
 
+bool
+io_interface_init_topology(bbl_interface_s *interface, int numa_node_hint);
+
 #endif

--- a/code/bngblaster/src/io/io_thread.c
+++ b/code/bngblaster/src/io/io_thread.c
@@ -8,9 +8,7 @@
  */
 #include "io.h"
 
-#define BBL_CPU_ID_MAX 4096
-
-static bool g_io_cpu_reserved[BBL_CPU_ID_MAX];
+static bool g_io_cpu_reserved[CPU_SETSIZE];
 
 /** 
  * This function redirects the packet in the
@@ -254,7 +252,7 @@ io_thread_auto_affinity(io_thread_s *thread, io_handle_s *io)
     start = *cursor % interface->local_cpuset_count;
     for(index = 0; index < interface->local_cpuset_count; index++) {
         cpu = interface->local_cpuset[(start + index) % interface->local_cpuset_count];
-        if(cpu < BBL_CPU_ID_MAX && !g_io_cpu_reserved[cpu]) {
+        if(cpu < CPU_SETSIZE && !g_io_cpu_reserved[cpu]) {
             CPU_SET(cpu, &thread->cpuset);
             thread->selected_cpu = cpu;
             g_io_cpu_reserved[cpu] = true;
@@ -333,7 +331,14 @@ io_thread_init(io_handle_s *io)
         thread->set_cpu_affinity = true;
         CPU_ZERO(&thread->cpuset);
         thread->selected_cpu = config->rx_cpuset[config->rx_cpuset_cur++];
-        CPU_SET(thread->selected_cpu, &thread->cpuset);
+        
+        if(thread->selected_cpu < CPU_SETSIZE) {
+            CPU_SET(thread->selected_cpu, &thread->cpuset);
+        }
+        if(thread->selected_cpu < CPU_SETSIZE) {
+            g_io_cpu_reserved[thread->selected_cpu] = true;
+        }
+
         if(config->rx_cpuset_cur >= config->rx_cpuset_count) {
             config->rx_cpuset_cur = 0;
         }
@@ -342,7 +347,14 @@ io_thread_init(io_handle_s *io)
         thread->set_cpu_affinity = true;
         CPU_ZERO(&thread->cpuset);
         thread->selected_cpu = config->tx_cpuset[config->tx_cpuset_cur++];
-        CPU_SET(thread->selected_cpu, &thread->cpuset);
+        
+        if(thread->selected_cpu < CPU_SETSIZE) {
+            CPU_SET(thread->selected_cpu, &thread->cpuset);
+        }
+        if(thread->selected_cpu < CPU_SETSIZE) {
+            g_io_cpu_reserved[thread->selected_cpu] = true;
+        }
+
         if(config->tx_cpuset_cur >= config->tx_cpuset_count) {
             config->tx_cpuset_cur = 0;
         }

--- a/code/bngblaster/src/io/io_thread.c
+++ b/code/bngblaster/src/io/io_thread.c
@@ -8,6 +8,10 @@
  */
 #include "io.h"
 
+#define BBL_CPU_ID_MAX 4096
+
+static bool g_io_cpu_reserved[BBL_CPU_ID_MAX];
+
 /** 
  * This function redirects the packet in the
  * IO buffer to the main thread via the TXQ 
@@ -218,6 +222,54 @@ io_thread_main(void *thread_data)
     return NULL;
 }
 
+static bool
+io_thread_auto_affinity(io_thread_s *thread, io_handle_s *io)
+{
+    bbl_interface_s *interface = io->interface;
+    bbl_link_config_s *config = interface->config;
+    uint16_t *cursor = NULL;
+    uint16_t start;
+    uint16_t index;
+    uint16_t cpu;
+
+    if(!interface->local_cpuset_count) {
+        return false;
+    }
+
+    if(io->direction == IO_INGRESS) {
+        if(!(config->rx_auto_cpuset && !config->rx_cpuset_count)) {
+            return false;
+        }
+        cursor = &config->rx_cpuset_cur;
+    } else {
+        if(!(config->tx_auto_cpuset && !config->tx_cpuset_count)) {
+            return false;
+        }
+        cursor = &config->tx_cpuset_cur;
+    }
+
+    thread->set_cpu_affinity = true;
+    CPU_ZERO(&thread->cpuset);
+
+    start = *cursor % interface->local_cpuset_count;
+    for(index = 0; index < interface->local_cpuset_count; index++) {
+        cpu = interface->local_cpuset[(start + index) % interface->local_cpuset_count];
+        if(cpu < BBL_CPU_ID_MAX && !g_io_cpu_reserved[cpu]) {
+            CPU_SET(cpu, &thread->cpuset);
+            thread->selected_cpu = cpu;
+            g_io_cpu_reserved[cpu] = true;
+            *cursor = (start + index + 1) % interface->local_cpuset_count;
+            return true;
+        }
+    }
+
+    cpu = interface->local_cpuset[start];
+    CPU_SET(cpu, &thread->cpuset);
+    thread->selected_cpu = cpu;
+    *cursor = (start + 1) % interface->local_cpuset_count;
+    return true;
+}
+
 bool
 io_thread_init(io_handle_s *io)
 {
@@ -280,7 +332,8 @@ io_thread_init(io_handle_s *io)
     if(io->direction == IO_INGRESS && config->rx_cpuset_count) {
         thread->set_cpu_affinity = true;
         CPU_ZERO(&thread->cpuset);
-        CPU_SET(config->rx_cpuset[config->rx_cpuset_cur++], &thread->cpuset);
+        thread->selected_cpu = config->rx_cpuset[config->rx_cpuset_cur++];
+        CPU_SET(thread->selected_cpu, &thread->cpuset);
         if(config->rx_cpuset_cur >= config->rx_cpuset_count) {
             config->rx_cpuset_cur = 0;
         }
@@ -288,10 +341,14 @@ io_thread_init(io_handle_s *io)
     if(io->direction == IO_EGRESS && config->tx_cpuset_count) {
         thread->set_cpu_affinity = true;
         CPU_ZERO(&thread->cpuset);
-        CPU_SET(config->tx_cpuset[config->tx_cpuset_cur++], &thread->cpuset);
+        thread->selected_cpu = config->tx_cpuset[config->tx_cpuset_cur++];
+        CPU_SET(thread->selected_cpu, &thread->cpuset);
         if(config->tx_cpuset_cur >= config->tx_cpuset_count) {
             config->tx_cpuset_cur = 0;
         }
+    }
+    if(!thread->set_cpu_affinity) {
+        io_thread_auto_affinity(thread, io);
     }
     return true;
 }

--- a/code/common/src/config.h
+++ b/code/common/src/config.h
@@ -14,6 +14,6 @@
 
 #define BUILD_OS ""
 #define COMPILER_ID "GNU"
-#define COMPILER_VERSION "11.4.0"
+#define COMPILER_VERSION "13.3.0"
 
 #endif

--- a/code/common/src/config.h
+++ b/code/common/src/config.h
@@ -14,6 +14,6 @@
 
 #define BUILD_OS ""
 #define COMPILER_ID "GNU"
-#define COMPILER_VERSION "13.3.0"
+#define COMPILER_VERSION "11.4.0"
 
 #endif

--- a/docs/_sources/configuration/interfaces_links.rst.txt
+++ b/docs/_sources/configuration/interfaces_links.rst.txt
@@ -21,11 +21,17 @@ for interface links referenced by interface functions.
 | **lacp-priority**                 | | LACP interface priority.                                           |
 |                                   | | Default: 32768                                                     |
 +-----------------------------------+----------------------------------------------------------------------+
-| **tx-cpuset**                     | | Optionally pin TX threads to CPU cores (cpuset). This is required  |
-|                                   | | for DPDK only.                                                     |
+| **tx-cpuset**                     | | Optionally pin TX threads to CPU cores (cpuset). Manual pinning    |
+|                                   | | overrides automatic CPU placement.                                 |
 +-----------------------------------+----------------------------------------------------------------------+
-| **rx-cpuset**                     | | Optionally pin RX threads to CPU cores (cpuset). This is required  |
-|                                   | | for DPDK only.                                                     |
+| **rx-cpuset**                     | | Optionally pin RX threads to CPU cores (cpuset). Manual pinning    |
+|                                   | | overrides automatic CPU placement.                                 |
++-----------------------------------+----------------------------------------------------------------------+
+| **tx-auto-cpuset**                | | Automatically pin TX threads to CPUs local to the interface.       |
+|                                   | | BNG Blaster prefers local physical cores before SMT siblings.      |
++-----------------------------------+----------------------------------------------------------------------+
+| **rx-auto-cpuset**                | | Automatically pin RX threads to CPUs local to the interface.       |
+|                                   | | BNG Blaster prefers local physical cores before SMT siblings.      |
 +-----------------------------------+----------------------------------------------------------------------+
 | **io-mode**                       | | Overwrite the IO mode.                                             |
 +-----------------------------------+----------------------------------------------------------------------+

--- a/docs/_sources/performance.rst.txt
+++ b/docs/_sources/performance.rst.txt
@@ -110,14 +110,14 @@ test environment.
 NUMA
 ----
 
-NUMA, which stands for Non-Uniform Memory Access, is a computer memory design used in multi-processor systems. 
-In a NUMA system, each processor, or a group of processors, has its own local memory. The processors can access 
-their own local memory faster than non-local memory, which is the memory local to another processor or shared 
+NUMA, which stands for Non-Uniform Memory Access, is a computer memory design used in multi-processor systems.
+In a NUMA system, each processor, or a group of processors, has its own local memory. The processors can access
+their own local memory faster than non-local memory, which is the memory local to another processor or shared
 between processors.
 
-On such systems, the best performance can be achieved by manually assigning RX and TX threads to a set of CPU
-to ensure that the corresponding threads of an interface are running on the same NUMA node. The NUMA node
-of the interface can be derived from the file ``/sys/class/net/<interface>/device/numa_node``. 
+On such systems, the best performance can be achieved by keeping RX and TX threads of an interface on CPUs
+that are local to the same NUMA node as the NIC. The NUMA node of the interface can be derived from the file
+``/sys/class/net/<interface>/device/numa_node``.
 
 .. code-block:: none
 
@@ -128,7 +128,7 @@ of the interface can be derived from the file ``/sys/class/net/<interface>/devic
 
 
 The command ``lscpu`` returns the number of NUMA nodes with the associated
-CPU's for each NUMA node. 
+CPU's for each NUMA node.
 
 .. code-block:: none
 
@@ -139,24 +139,60 @@ CPU's for each NUMA node.
     NUMA node1 CPU(s):     18-35,54-71
 
 
-Folowing an example configuration.
+BNG Blaster supports two approaches:
+
+* Manual pinning with ``rx-cpuset`` and ``tx-cpuset``.
+* Automatic pinning with ``rx-auto-cpuset`` and ``tx-auto-cpuset``.
+
+When automatic pinning is enabled, BNG Blaster derives the local CPU list from the interface and tries to
+optimize placement as follows:
+
+* Prefer CPUs local to the NIC.
+* Prefer one hardware thread per physical core before using SMT siblings.
+* Avoid reusing the same CPU across interfaces until the local CPU pool is exhausted.
+* Fall back to the NUMA node CPU list and finally to the system online CPU list if no local CPU list is exposed.
+
+Following an example configuration using automatic CPU placement.
 
 .. code-block:: json
 
-  {
+    {
+        "interfaces": {
+            "rx-auto-cpuset": true,
+            "tx-auto-cpuset": true,
+            "links": [
+                {
+                    "interface": "eth0",
+                    "rx-threads": 4,
+                    "tx-threads": 4
+                },
+                {
+                    "interface": "eth1",
+                    "rx-threads": 4,
+                    "tx-threads": 4
+                }
+            ]
+        }
+    }
+
+Following an example configuration with manual pinning.
+
+.. code-block:: json
+
+    {
         "interfaces": {
             "links": [
                 {
                     "interface": "eth0",
                     "rx-threads": 4,
-                    "rx-cpuset": [0, 36, 1, 37]
+                    "rx-cpuset": [0, 36, 1, 37],
                     "tx-threads": 4,
                     "tx-cpuset": [2, 38, 3, 39]
                 },
                 {
                     "interface": "eth1",
                     "rx-threads": 4,
-                    "rx-cpuset": [18, 54, 19, 55]
+                    "rx-cpuset": [18, 54, 19, 55],
                     "tx-threads": 4,
                     "tx-cpuset": [20, 56, 21, 57]
                 }
@@ -165,9 +201,9 @@ Folowing an example configuration.
     }
 
 
-Following a real world example from a system with two CPU sockets (NUMA nodes) and two physical NIC adapters, 
-each connected to another socket (NUMA node). This example was optimized to send loss free 20G from 
-ens2f2np2, ens2f3np3 (NUMA node 0) to ens5f2np2, ens5f3np3 (NUMA node 1).  
+Following a real world example from a system with two CPU sockets (NUMA nodes) and two physical NIC adapters,
+each connected to another socket (NUMA node). This example was optimized to send loss free 20G from
+ens2f2np2, ens2f3np3 (NUMA node 0) to ens5f2np2, ens5f3np3 (NUMA node 1).
 
 .. code-block:: json
 
@@ -201,7 +237,10 @@ ens2f2np2, ens2f3np3 (NUMA node 0) to ens5f2np2, ens5f3np3 (NUMA node 1).
     } 
 
 
-This example shows well that more RX threads are required than TX threads. 
+This example shows well that more RX threads are required than TX threads.
+
+For DPDK interfaces, the same automatic placement options are available. The DPDK backend derives the NIC
+socket from ``rte_eth_dev_socket_id()`` and applies the same locality and physical-core-first policy.
 
 
 .. _dpdk-usage:
@@ -222,7 +261,35 @@ in the corresponding :ref:`installation <install-dpdk>` section.
 
     {
         "interfaces": {
-            "io-slots": 32768
+            "io-slots": 32768,
+            "links": [
+                {
+                    "interface": "0000:23:00.0",
+                    "io-mode": "dpdk",
+                    "rx-threads": 8,
+                    "rx-auto-cpuset": true,
+                    "tx-threads": 3,
+                    "tx-auto-cpuset": true
+                },
+                {
+                    "interface": "0000:23:00.2",
+                    "io-mode": "dpdk",
+                    "rx-threads": 8,
+                    "rx-auto-cpuset": true,
+                    "tx-threads": 3,
+                    "tx-auto-cpuset": true
+                }
+            ]
+        }
+    }
+
+Manual DPDK pinning remains available if you need exact CPU control.
+
+.. code-block:: json
+
+    {
+        "interfaces": {
+            "io-slots": 32768,
             "links": [
                 {
                     "interface": "0000:23:00.0",
@@ -231,51 +298,9 @@ in the corresponding :ref:`installation <install-dpdk>` section.
                     "rx-cpuset": [4,5,6,7],
                     "tx-threads": 3,
                     "tx-cpuset": [1,2,3]
-                },
-                {
-                    "interface": "0000:23:00.2",
-                    "io-mode": "dpdk",
-                    "rx-threads": 8,
-                    "rx-cpuset": [12,13,14,15],
-                    "tx-threads": 3,
-                    "tx-cpuset": [9,10,11]
-                }
-            ],
-            "a10nsp": [
-                {
-                    "__comment__": "PPPoE Server",
-                    "interface": "0000:23:00.0"
-                }
-            ],
-            "access": [
-                {
-                    "__comment__": "PPPoE Client",
-                    "interface": "0000:23:00.2",
-                    "type": "pppoe",
-                    "outer-vlan-min": 1,
-                    "outer-vlan-max": 4000,
-                    "inner-vlan-min": 1,
-                    "inner-vlan-max": 4000,
-                    "stream-group-id": 1
                 }
             ]
-        },
-        "pppoe": {
-            "reconnect": true
-        },
-        "dhcpv6": {
-            "enable": false
-        },
-        "streams": [
-            {
-                "stream-group-id": 1,
-                "name": "S1",
-                "type": "ipv4",
-                "direction": "both",
-                "pps": 1000,
-                "a10nsp-interface": "0000:23:00.0"
-            }
-        ]
+        }
     }
 
 

--- a/examples/tmp.json
+++ b/examples/tmp.json
@@ -1,0 +1,168 @@
+{
+  "interfaces": {
+    "a10nsp-dynamic": true,
+    "lag": [
+      {
+        "interface": "lag1",
+        "lacp": true,
+        "lacp-timeout-short": true
+      },
+      {
+        "interface": "lag2",
+        "lacp": false
+      }
+    ],
+    "links": [
+      {
+        "interface": "SN-18-B1",
+        "lag-interface": "lag1"
+      },
+      {
+        "interface": "SN-19-B1",
+        "lag-interface": "lag1"
+      },
+      {
+        "interface": "SN-20-B1",
+        "lag-interface": "lag2"
+      }
+    ],
+    "a10nsp": [
+      {
+        "__comment__": "A10NSP via lag1",
+        "interface": "lag1"
+      },
+      {
+        "__comment__": "A10NSP via lag2",
+        "interface": "lag2"
+      }
+    ],
+    "access": [
+      {
+        "interface": "SN-7-L1",
+        "type": "pppoe",
+        "outer-vlan-min": 64,
+        "outer-vlan-max": 4063,
+        "inner-vlan": 7,
+        "stream-group-id": 1
+      },
+      {
+        "interface": "SN-12-L1",
+        "type": "ipoe",
+        "outer-vlan-min": 64,
+        "outer-vlan-max": 4063,
+        "inner-vlan": 7,
+        "dhcp": true,
+        "stream-group-id": 1
+      }
+    ]
+  },
+  "sessions": {
+    "count": 4
+  },
+  "pppoe": {
+    "reconnect": true,
+    "discovery-timeout": 3,
+    "discovery-retry": 10,
+    "host-uniq": true,
+    "vlan-priority": 6
+  },
+  "ppp": {
+    "mru": 1492,
+    "authentication": {
+      "username": "user{session-global}@t-online.de",
+      "password": "test"
+    }
+  },
+  "dhcpv6": {
+    "enable": true
+  },
+  "access-line": {
+    "agent-remote-id": "DEU.RTBRICK.{session-global}",
+    "agent-circuit-id": "0.0.0.0/0.0.0.0 eth 0:{session-global}"
+  },
+  "session-traffic": {
+    "autostart": true,
+    "ipv4-pps": 1,
+    "ipv6-pps": 1
+  },
+  "streams": [
+    {
+      "name": "P0",
+      "stream-group-id": 1,
+      "type": "ipv4",
+      "direction": "both",
+      "pps": 1,
+      "destination-ipv4-address": "10.0.0.0"
+    },
+    {
+      "name": "P1",
+      "stream-group-id": 1,
+      "type": "ipv4",
+      "direction": "both",
+      "pps": 1,
+      "vlan-priority": 1,
+      "priority": 1,
+      "destination-ipv4-address": "10.0.0.1"
+    },
+    {
+      "name": "P2",
+      "stream-group-id": 1,
+      "type": "ipv4",
+      "direction": "both",
+      "pps": 1,
+      "vlan-priority": 2,
+      "priority": 2,
+      "destination-ipv4-address": "10.0.0.2"
+    },
+    {
+      "name": "P3",
+      "stream-group-id": 1,
+      "type": "ipv4",
+      "direction": "both",
+      "pps": 1,
+      "vlan-priority": 3,
+      "priority": 3,
+      "destination-ipv4-address": "10.0.0.3"
+    },
+    {
+      "name": "P4",
+      "stream-group-id": 1,
+      "type": "ipv4",
+      "direction": "both",
+      "pps": 1,
+      "vlan-priority": 4,
+      "priority": 4,
+      "destination-ipv4-address": "10.0.0.4"
+    },
+    {
+      "name": "P5",
+      "stream-group-id": 1,
+      "type": "ipv4",
+      "direction": "both",
+      "pps": 1,
+      "vlan-priority": 5,
+      "priority": 5,
+      "destination-ipv4-address": "10.0.0.5"
+    },
+    {
+      "name": "P6",
+      "stream-group-id": 1,
+      "type": "ipv4",
+      "direction": "both",
+      "pps": 1,
+      "vlan-priority": 6,
+      "priority": 6,
+      "destination-ipv4-address": "10.0.0.6"
+    },
+    {
+      "name": "P7",
+      "stream-group-id": 1,
+      "type": "ipv4",
+      "direction": "both",
+      "pps": 1,
+      "vlan-priority": 7,
+      "priority": 7,
+      "destination-ipv4-address": "10.0.0.7"
+    }
+  ]
+}

--- a/schemas/bngblaster-config.json
+++ b/schemas/bngblaster-config.json
@@ -66,6 +66,16 @@
                     "minimum": 0,
                     "maximum": 255
                 },
+                "tx-auto-cpuset": {
+                    "type": "boolean",
+                    "description": "Automatically pin TX threads to CPUs local to the interface",
+                    "default": false
+                },
+                "rx-auto-cpuset": {
+                    "type": "boolean",
+                    "description": "Automatically pin RX threads to CPUs local to the interface",
+                    "default": false
+                },
                 "capture-include-streams": {
                     "type": "boolean",
                     "description": "Include traffic streams in the capture",
@@ -2120,6 +2130,11 @@
                     "uniqueItems": true,
                     "minItems": 1
                 },
+                "tx-auto-cpuset": {
+                    "type": "boolean",
+                    "description": "Automatically pin TX threads to CPUs local to this interface",
+                    "default": false
+                },
                 "rx-cpuset": {
                     "type": "array",
                     "description": "Pin RX threads to CPU cores (cpuset)",
@@ -2130,6 +2145,11 @@
                     },
                     "uniqueItems": true,
                     "minItems": 1
+                },
+                "rx-auto-cpuset": {
+                    "type": "boolean",
+                    "description": "Automatically pin RX threads to CPUs local to this interface",
+                    "default": false
                 },
                 "io-mode": {
                     "type": "string",


### PR DESCRIPTION
REPLACED: https://github.com/rtbrick/bngblaster/pull/390

## Summary

This PR adds automatic CPU/NUMA-aware thread placement for BNG Blaster interfaces.

When `rx-auto-cpuset` or `tx-auto-cpuset` is enabled, BNG Blaster now discovers the CPU topology local to the interface and pins RX/TX threads automatically. This reduces the need for hand-written `rx-cpuset` / `tx-cpuset` mappings on NUMA systems while keeping manual pinning available and preferred when explicitly configured.

## Changes

- Add `rx-auto-cpuset` and `tx-auto-cpuset` config options globally under `interfaces` and per interface link.
- Discover interface-local CPUs from sysfs:
  - kernel interfaces via `/sys/class/net/<if>/device/...`
  - DPDK PCI devices via `/sys/bus/pci/devices/<pci>/...`
- Prefer NIC-local CPUs, then NUMA node CPUs, then system online CPUs as fallback.
- Prefer one hardware thread per physical core before using SMT siblings.
- Avoid CPU reuse across interfaces until the local CPU pool is exhausted.
- Add DPDK support using `rte_eth_dev_socket_id()` as NUMA hint.
- Track and expose the selected CPU per IO thread.
- Add `interface-topology` control socket command and CLI output for inspecting:
  - IO mode
  - NUMA node
  - discovered local CPU set
  - RX/TX thread CPU source and selected CPU
  - DPDK queue where applicable
- Update JSON schema and performance/interface documentation.
- Also includes IPoE VLAN priority handling for ARP and ICMPv6 ND/RS/NS, with related documentation updates.

## Example

```json
{
  "interfaces": {
    "rx-auto-cpuset": true,
    "tx-auto-cpuset": true,
    "links": [
      {
        "interface": "eth0",
        "rx-threads": 4,
        "tx-threads": 4
      }
    ]
  }
}
```

Manual `rx-cpuset` / `tx-cpuset` configuration still overrides automatic placement.

## Verification

- `git diff --check upstream/dev...HEAD`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`

All local tests passed.
```

