### PR TITLE
add network-interface inner-vlan and qinq

### DIFF
--- a/code/bngblaster/src/bbl_config.c
+++ b/code/bngblaster/src/bbl_config.c
@@ -840,8 +840,9 @@ json_parse_network_interface(json_t *network_interface, bbl_network_config_s *ne
     const char *schema[] = {
         "interface", "address", "gateway",
         "address-ipv6", "gateway-ipv6", "ipv6-router-advertisement",
-        "gateway-mac", "vlan", "mtu", "gateway-resolve-wait", 
-        "isis-instance-id", "isis-level", "isis-p2p", 
+        "gateway-mac", "vlan", "inner-vlan", "qinq", "mtu", 
+        "gateway-resolve-wait",
+        "isis-instance-id", "isis-level", "isis-p2p",
         "isis-l1-metric", "isis-l2-metric",
         "isis-l1-priority", "isis-l2-priority",
         "ospfv2-instance-id", "ospfv2-metric", "ospfv2-type",
@@ -912,6 +913,23 @@ json_parse_network_interface(json_t *network_interface, bbl_network_config_s *ne
     if(value) {
         network_config->vlan = json_number_value(value);
         network_config->vlan &= 4095;
+    }
+    JSON_OBJ_GET_NUMBER(network_interface, value, "access", "inner-vlan", 0, 4095);
+    if(value) {
+        network_config->inner_vlan = json_number_value(value);
+        network_config->inner_vlan &= 4095;
+        if(network_config->inner_vlan && network_config->vlan == 0) {
+            fprintf(stderr, "JSON config error: Network interface with inner-vlan but no vlan (outer)\n");
+            return false;
+        }
+    }
+    JSON_OBJ_GET_BOOL(network_interface, value, "access", "qinq");
+    if(value) {
+        network_config->qinq = json_boolean_value(value);
+        if(network_config->qinq && network_config->inner_vlan == 0) {
+            fprintf(stderr, "JSON config error: Enabling qinq on network interfaces requires an inner-vlan\n");
+            return false;
+        }
     }
     JSON_OBJ_GET_NUMBER(network_interface, value, "network", "mtu", 64, 9000);
     if(value) {

--- a/code/bngblaster/src/bbl_config.h
+++ b/code/bngblaster/src/bbl_config.h
@@ -135,7 +135,9 @@ typedef struct bbl_network_config_
     uint8_t mac[ETH_ADDR_LEN];
     uint8_t gateway_mac[ETH_ADDR_LEN];
     bool gateway_resolve_wait;
+    bool qinq; /* use ethertype 0x88a8 */
     uint16_t vlan;
+    uint16_t inner_vlan;
     uint16_t mtu;
     
     ipv4_prefix ip;

--- a/code/bngblaster/src/bbl_icmp_client.c
+++ b/code/bngblaster/src/bbl_icmp_client.c
@@ -65,7 +65,8 @@ bbl_icmp_client_tx(bbl_icmp_client_s *client, bbl_icmp_s *icmp)
         eth.dst = network_interface->gateway_mac;
         eth.src = network_interface->mac;
         eth.vlan_outer = network_interface->vlan;
-        eth.vlan_inner = 0;
+        eth.vlan_inner = network_interface->inner_vlan;
+        eth.qinq = network_interface->qinq;
         ipv4.src = client->src;
     }
 

--- a/code/bngblaster/src/bbl_l2tp.c
+++ b/code/bngblaster/src/bbl_l2tp.c
@@ -454,6 +454,8 @@ bbl_l2tp_send(bbl_l2tp_tunnel_s *l2tp_tunnel, bbl_l2tp_session_s *l2tp_session, 
     eth.dst = interface->gateway_mac;
     eth.src = interface->mac;
     eth.vlan_outer = interface->vlan;
+    eth.vlan_inner = interface->inner_vlan;
+    eth.qinq = interface->qinq;
     eth.type = ETH_TYPE_IPV4;
     eth.next = &ipv4;
     ipv4.dst = l2tp_tunnel->peer_ip;
@@ -540,6 +542,8 @@ bbl_l2tp_send_data(bbl_l2tp_session_s *l2tp_session, uint16_t protocol, void *ne
     eth.dst = interface->gateway_mac;
     eth.src = interface->mac;
     eth.vlan_outer = interface->vlan;
+    eth.vlan_inner = interface->inner_vlan;
+    eth.qinq = interface->qinq;
     eth.type = ETH_TYPE_IPV4;
     eth.next = &ipv4;
     ipv4.dst = l2tp_tunnel->peer_ip;

--- a/code/bngblaster/src/bbl_network.c
+++ b/code/bngblaster/src/bbl_network.c
@@ -71,6 +71,10 @@ bbl_network_interfaces_add()
             LOG(ERROR, "Failed to add network interface %s (untagged not allowed on access interfaces)\n", ifname);
             return false;
         }
+        if(interface->network_vlan[network_config->vlan]) {
+            LOG(ERROR, "Failed to add network interface %s (outer VLAN must be unique)\n", ifname);
+            return false;
+        }
 
         network_interface = calloc(1, sizeof(bbl_network_interface_s));
         network_interface->next = interface->network;
@@ -93,6 +97,8 @@ bbl_network_interfaces_add()
 
         /* Init ethernet */
         network_interface->vlan = network_config->vlan;
+        network_interface->inner_vlan = network_config->inner_vlan;
+        network_interface->qinq = network_config->qinq;
         network_interface->mtu = network_config->mtu;
 
         if(*(uint32_t*)network_config->mac) {
@@ -306,7 +312,8 @@ bbl_network_update_eth(bbl_network_interface_s *interface,
     eth->dst = eth->src;
     eth->src = interface->mac;
     eth->vlan_outer = interface->vlan;
-    eth->vlan_inner = 0;
+    eth->vlan_inner = interface->inner_vlan;
+    eth->qinq = interface->qinq;
     eth->vlan_three = 0;
     if(interface->tx_label.label) {
         eth->mpls = &interface->tx_label;

--- a/code/bngblaster/src/bbl_network.h
+++ b/code/bngblaster/src/bbl_network.h
@@ -29,6 +29,8 @@ typedef struct bbl_network_interface_
 
     uint16_t mtu;
     uint16_t vlan;
+    uint16_t inner_vlan;
+
     bbl_mpls_s tx_label;
     
     uint8_t mac[ETH_ADDR_LEN];
@@ -41,6 +43,7 @@ typedef struct bbl_network_interface_
     ipv4addr_t  gateway;
 
     bool ipv6_ra;
+    bool qinq;
 
     ipv6_prefix ip6; /* global IPv6 address */
     ipv6addr_t  ip6_ll; /* link-local IPv6 address */

--- a/code/bngblaster/src/bbl_stream.c
+++ b/code/bngblaster/src/bbl_stream.c
@@ -711,7 +711,8 @@ bbl_stream_build_network_packet(bbl_stream_s *stream)
     eth.src = network_interface->mac;
     eth.vlan_outer = network_interface->vlan;
     eth.vlan_outer_priority = config->vlan_priority;
-    eth.vlan_inner = 0;
+    eth.vlan_inner = network_interface->inner_vlan;
+    eth.qinq = network_interface->qinq;
 
     /* Add MPLS labels */
     if(config->tx_mpls1 || stream->ldp_entry) {
@@ -880,7 +881,8 @@ bbl_stream_build_l2tp_packet(bbl_stream_s *stream)
     eth.dst = network_interface->gateway_mac;
     eth.src = network_interface->mac;
     eth.vlan_outer = network_interface->vlan;
-    eth.vlan_inner = 0;
+    eth.vlan_inner = network_interface->inner_vlan;
+    eth.qinq = network_interface->qinq;
     eth.type = ETH_TYPE_IPV4;
     eth.next = &l2tp_ipv4;
     l2tp_ipv4.dst = l2tp_tunnel->peer_ip;

--- a/code/bngblaster/src/bbl_tcp.c
+++ b/code/bngblaster/src/bbl_tcp.c
@@ -1075,6 +1075,8 @@ bbl_tcp_netif_output_ipv4(struct netif *netif, struct pbuf *p, const ip4_addr_t 
     eth.dst = interface->gateway_mac;
     eth.src = interface->mac;
     eth.vlan_outer = interface->vlan;
+    eth.vlan_inner = interface->inner_vlan;
+    eth.qinq = interface->qinq;
     eth.type = ETH_TYPE_IPV4;
     eth.lwip = true;
     eth.next = p;
@@ -1144,6 +1146,8 @@ bbl_tcp_netif_output_ipv6(struct netif *netif, struct pbuf *p, const ip6_addr_t 
     eth.dst = interface->gateway6_mac;
     eth.src = interface->mac;
     eth.vlan_outer = interface->vlan;
+    eth.vlan_inner = interface->inner_vlan;
+    eth.qinq = interface->qinq;
     eth.type = ETH_TYPE_IPV6;
     eth.lwip = true;
     eth.next = p;

--- a/code/bngblaster/src/bbl_tx.c
+++ b/code/bngblaster/src/bbl_tx.c
@@ -1647,6 +1647,8 @@ bbl_tx_encode_network_packet(bbl_network_interface_s *interface, uint8_t *buf, u
 
     eth.src = interface->mac;
     eth.vlan_outer = interface->vlan;
+    eth.vlan_inner = interface->inner_vlan;
+    eth.qinq = interface->qinq;
     if(interface->send_requests & BBL_IF_SEND_ARP_REQUEST) {
         interface->send_requests &= ~BBL_IF_SEND_ARP_REQUEST;
         eth.type = ETH_TYPE_ARP;

--- a/code/bngblaster/src/isis/isis_csnp.c
+++ b/code/bngblaster/src/isis/isis_csnp.c
@@ -36,6 +36,7 @@ isis_csnp_job(timer_s *timer)
     isis_tlv_s *tlv;
     isis_lsp_entry_s *entry;
 
+    bbl_network_interface_s *interface = adjacency->interface;
     bbl_ethernet_header_s eth = {0};
     bbl_isis_s isis = {0};
 
@@ -156,8 +157,10 @@ isis_csnp_job(timer_s *timer)
     /* Send packet ... */
     eth.type = ISIS_PROTOCOL_IDENTIFIER;
     eth.next = &isis;
-    eth.src = adjacency->interface->mac;
-    eth.vlan_outer = adjacency->interface->vlan;
+    eth.src = interface->mac;
+    eth.vlan_outer = interface->vlan;
+    eth.vlan_inner = interface->inner_vlan;
+    eth.qinq = interface->qinq;
     if(adjacency->level == ISIS_LEVEL_1) {
         eth.dst = g_isis_mac_all_l1;
         isis.type = ISIS_PDU_L1_CSNP;
@@ -167,14 +170,14 @@ isis_csnp_job(timer_s *timer)
     }
     isis.pdu = pdu.pdu;
     isis.pdu_len = pdu.pdu_len;
-    if(bbl_txq_to_buffer(adjacency->interface->txq, &eth) == BBL_TXQ_OK) {
+    if(bbl_txq_to_buffer(interface->txq, &eth) == BBL_TXQ_OK) {
         LOG(PACKET, "ISIS TX %s on interface %s\n",
-            isis_pdu_type_string(isis.type), adjacency->interface->name);
+            isis_pdu_type_string(isis.type), interface->name);
         adjacency->stats.csnp_tx++;
-        adjacency->interface->stats.isis_tx++;
+        interface->stats.isis_tx++;
     } else {
         LOG(ERROR, "Failed to send ISIS %s on interface %s\n",
-            isis_pdu_type_string(isis.type), adjacency->interface->name);
+            isis_pdu_type_string(isis.type), interface->name);
     }
     return;
 }

--- a/code/bngblaster/src/isis/isis_lsp.c
+++ b/code/bngblaster/src/isis/isis_lsp.c
@@ -347,8 +347,10 @@ isis_lsp_tx_job(timer_s *timer)
     isis_adjacency_s *adjacency = timer->data;
     isis_flood_entry_s *entry;
     isis_lsp_s *lsp;
+
     uint16_t window = adjacency->window_size;
 
+    bbl_network_interface_s *interface = adjacency->interface;
     bbl_ethernet_header_s eth = {0};
     bbl_isis_s isis = {0};
 
@@ -364,8 +366,10 @@ isis_lsp_tx_job(timer_s *timer)
 
     eth.type = ISIS_PROTOCOL_IDENTIFIER;
     eth.next = &isis;
-    eth.src = adjacency->interface->mac;
-    eth.vlan_outer = adjacency->interface->vlan;
+    eth.src = interface->mac;
+    eth.vlan_outer = interface->vlan;
+    eth.vlan_inner = interface->inner_vlan;
+    eth.qinq = interface->qinq;
     if(adjacency->level == ISIS_LEVEL_1) {
         eth.dst = g_isis_mac_all_l1;
         isis.type = ISIS_PDU_L1_LSP;
@@ -427,6 +431,7 @@ isis_lsp_tx_p2p_job(timer_s *timer)
     bool next;
     uint16_t window = adjacency->window_size;
 
+    bbl_network_interface_s *interface = adjacency->interface;
     bbl_ethernet_header_s eth = {0};
     bbl_isis_s isis = {0};
 
@@ -438,8 +443,10 @@ isis_lsp_tx_p2p_job(timer_s *timer)
 
     eth.type = ISIS_PROTOCOL_IDENTIFIER;
     eth.next = &isis;
-    eth.src = adjacency->interface->mac;
-    eth.vlan_outer = adjacency->interface->vlan;
+    eth.src = interface->mac;
+    eth.vlan_outer = interface->vlan;
+    eth.vlan_inner = interface->inner_vlan;
+    eth.qinq = interface->qinq;
     if(adjacency->level == ISIS_LEVEL_1) {
         eth.dst = g_isis_mac_all_l1;
         isis.type = ISIS_PDU_L1_LSP;

--- a/code/bngblaster/src/isis/isis_psnp.c
+++ b/code/bngblaster/src/isis/isis_psnp.c
@@ -31,6 +31,7 @@ isis_psnp_job(timer_s *timer)
     isis_tlv_s *tlv;
     isis_lsp_entry_s *entry;
 
+    bbl_network_interface_s *interface = adjacency->interface;
     bbl_ethernet_header_s eth = {0};
     bbl_isis_s isis = {0};
 
@@ -140,8 +141,10 @@ isis_psnp_job(timer_s *timer)
     /* Send packet ... */
     eth.type = ISIS_PROTOCOL_IDENTIFIER;
     eth.next = &isis;
-    eth.src = adjacency->interface->mac;
-    eth.vlan_outer = adjacency->interface->vlan;
+    eth.src = interface->mac;
+    eth.vlan_outer = interface->vlan;
+    eth.vlan_inner = interface->inner_vlan;
+    eth.qinq = interface->qinq;
     if(adjacency->level == ISIS_LEVEL_1) {
         eth.dst = g_isis_mac_all_l1;
         isis.type = ISIS_PDU_L1_PSNP;
@@ -151,14 +154,14 @@ isis_psnp_job(timer_s *timer)
     }
     isis.pdu = pdu.pdu;
     isis.pdu_len = pdu.pdu_len;
-    if(bbl_txq_to_buffer(adjacency->interface->txq, &eth) == BBL_TXQ_OK) {
+    if(bbl_txq_to_buffer(interface->txq, &eth) == BBL_TXQ_OK) {
         LOG(PACKET, "ISIS TX %s on interface %s\n",
-            isis_pdu_type_string(isis.type), adjacency->interface->name);
+            isis_pdu_type_string(isis.type), interface->name);
         adjacency->stats.psnp_tx++;
-        adjacency->interface->stats.isis_tx++;
+        interface->stats.isis_tx++;
     } else {
         LOG(ERROR, "Failed to send ISIS %s on interface %s\n",
-            isis_pdu_type_string(isis.type), adjacency->interface->name);
+            isis_pdu_type_string(isis.type), interface->name);
     }
     return;
 }

--- a/code/bngblaster/src/ospf/ospf_pdu.c
+++ b/code/bngblaster/src/ospf/ospf_pdu.c
@@ -426,7 +426,6 @@ ospf_pdu_tx(ospf_pdu_s *pdu,
             ospf_neighbor_s *ospf_neighbor)
 {
     bbl_network_interface_s *interface = ospf_interface->interface;
-
     bbl_ethernet_header_s eth = {0};
     bbl_ipv4_s ipv4 = {0};
     bbl_ipv6_s ipv6 = {0};
@@ -438,6 +437,8 @@ ospf_pdu_tx(ospf_pdu_s *pdu,
 
     eth.src = interface->mac;
     eth.vlan_outer = interface->vlan;
+    eth.vlan_inner = interface->inner_vlan;
+    eth.qinq = interface->qinq;
     if(ospf_interface->version == OSPF_VERSION_2) {
         eth.type = ETH_TYPE_IPV4;
         eth.next = &ipv4;

--- a/docsrc/sources/configuration/interfaces_network.rst
+++ b/docsrc/sources/configuration/interfaces_network.rst
@@ -24,6 +24,12 @@
 | **vlan**                          | | Network interface VLAN.                                            |
 |                                   | | Default: 0 (untagged)                                              |
 +-----------------------------------+----------------------------------------------------------------------+
+| **inner-vlan**                    | | Network interface inner VLAN.                                      |
+|                                   | | Default: 0 (single/untagged)                                       |
++-----------------------------------+----------------------------------------------------------------------+
+| **qinq**                          | | Set outer VLAN ethertype to QinQ (0x88a8).                         |
+|                                   | | Default: false                                                     |
++-----------------------------------+----------------------------------------------------------------------+
 | **gateway-mac**                   | | Optional set default gateway MAC address manually. Per default     |
 |                                   | | this MAC address is resolved via ARP/ND.                           |
 +-----------------------------------+----------------------------------------------------------------------+

--- a/docsrc/sources/interfaces.rst
+++ b/docsrc/sources/interfaces.rst
@@ -277,6 +277,15 @@ in the configuration to distinguish between them.
     }
 
 
+Double-tagged or QinQ configurations for network interfaces are partially supported, 
+allowing for an additional inner VLAN and optional QinQ when an outer VLAN is already 
+in place. However, a key constraint remains: the outer VLAN must be unique for each link. 
+While you can configure VLAN pairs such as ``100:1`` and ``101:2``, you cannot assign 
+both ``100:1`` and ``100:2`` to the same link interface. Additionally, network interface 
+referencing continues to be based solely on the name and outer VLAN; for example, ``eth1`` 
+with outer VLAN ``200`` and inner VLAN ``1`` is still referenced as ``eth1:200``.
+
+
 .. _access-interface:
 
 Access Interfaces


### PR DESCRIPTION
This merge request introduces support for `inner-vlan` and `qinq` on network interfaces. However, it retains the limitation that the outer VLAN must be unique per link. For example, configuring VLAN pairs like `100:1` and `101:2` is supported, but configuring `100:1` and `100:2` on the same network interface is not allowed. 