### PR TITLE
destination mac override for network streams per flow

### DIFF
--- a/code/bngblaster/src/bbl_config.c
+++ b/code/bngblaster/src/bbl_config.c
@@ -2504,7 +2504,7 @@ json_parse_stream(json_t *stream, bbl_stream_config_s *stream_config)
         "ldp-ipv4-lookup-address", "ldp-ipv6-lookup-address", 
         "access-ipv4-source-address", "access-ipv6-source-address",
         "network-ipv4-address", "network-ipv6-address", "destination-ipv4-address",
-        "destination-ipv6-address", "ipv4-df", "tx-label1",
+        "destination-ipv6-address", "destination-mac", "ipv4-df", "tx-label1",
         "tx-label1-exp", "tx-label1-ttl", "tx-label2",
         "tx-label2-exp", "tx-label2-ttl", "rx-label1",
         "rx-label2", "nat", "raw-tcp", "setup-interval"
@@ -2837,6 +2837,21 @@ json_parse_stream(json_t *stream, bbl_stream_config_s *stream_config)
             fprintf(stderr, "JSON config error: Invalid value for stream->destination-ipv6-address\n");
             return false;
         }
+    }
+
+    if(json_unpack(stream, "{s:s}", "destination-mac", &s) == 0) {
+        if(sscanf(s, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+                &stream_config->destination_mac[0],
+                &stream_config->destination_mac[1],
+                &stream_config->destination_mac[2],
+                &stream_config->destination_mac[3],
+                &stream_config->destination_mac[4],
+                &stream_config->destination_mac[5]) < 6)
+        {
+            fprintf(stderr, "JSON config error: Invalid value for stream->destination-mac\n");
+            return false;
+        }
+        stream_config->destination_mac_set = true;
     }
 
     /* Set DF bit for IPv4 traffic (default true) */

--- a/code/bngblaster/src/bbl_stream.c
+++ b/code/bngblaster/src/bbl_stream.c
@@ -837,6 +837,10 @@ bbl_stream_build_network_packet(bbl_stream_s *stream)
             return false;
     }
 
+    if(config->destination_mac_set) {
+        eth.dst = config->destination_mac;
+    }
+
     buf_len = config->length + BBL_MAX_STREAM_OVERHEAD;
     if(buf_len < 256) buf_len = 256;
     stream->tx_buf = malloc(buf_len);

--- a/code/bngblaster/src/bbl_stream.h
+++ b/code/bngblaster/src/bbl_stream.h
@@ -59,6 +59,8 @@ typedef struct bbl_stream_config_
     ipv6addr_t ipv6_network_address; /* overwrite default IPv6 network address */
     uint32_t ipv4_destination_address; /* overwrite IPv4 destination address */
     ipv6addr_t ipv6_destination_address; /* overwrite IPv6 destination address */
+    uint8_t destination_mac[ETH_ADDR_LEN]; /* overwrite destination MAC address */
+    bool destination_mac_set;
     char *network_interface;
     char *a10nsp_interface;
 

--- a/docsrc/sources/configuration/streams.rst
+++ b/docsrc/sources/configuration/streams.rst
@@ -97,6 +97,8 @@
 +--------------------------------+------------------------------------------------------------------+
 | **network-interface**          | | Select the corresponding network interface for this stream.    |
 +--------------------------------+------------------------------------------------------------------+
+| **destination-mac**            | | Overwrite network interface MAC address.                       |
++--------------------------------+------------------------------------------------------------------+
 | **network-ipv4-address**       | | Overwrite network interface IPv4 address.                      |
 +--------------------------------+------------------------------------------------------------------+
 | **network-ipv6-address**       | | Overwrite network interface IPv6 address.                      |


### PR DESCRIPTION
This change add config option "destination-mac" for network streams. It allow a per flow modification for destination-mac. 

Multiple use-case:
- ignore mac learning status
- in l2vpn scenarios needed to generate BUM traffic 
- l2 streams for control plane security checks (ARP/ND policer)
- if destination addresses not resolvable at instance bringup 

Example configuration:
```
{
  "interfaces": {
    "network": [
      {
        "interface": "ens192",
        "address": "172.16.0.1/31",
        "gateway": "172.16.0.0",
        "gateway-resolve-wait": false
      }
    ]
  },
  "streams": [
    {
      "name": "L3StaticV4_1",
      "type": "ipv4",
      "direction": "downstream",
      "network-interface": "ens192",
      "destination-ipv4-address": "10.0.0.1",
      "network-ipv4-address": "172.16.0.1",
      "destination-mac": "11:22:33:44:55:01",
      "priority": 232,
      "length": 128,
      "pps": 1
    }
  ]
}
```