### PR TITLE
Fix typo in documentation: ospf routing example config

### DIFF
--- a/docsrc/sources/routing/ospf.rst
+++ b/docsrc/sources/routing/ospf.rst
@@ -36,7 +36,7 @@ attached to two network interfaces.
                     "address": "10.0.1.2/30",
                     "gateway": "10.0.1.1",
                     "ospfv2-instance-id": 1,
-                    "ospfv2-type": "p2p",
+                    "ospfv2-type": "p2p"
                 },
                 {
                     "interface": "eth2",


### PR DESCRIPTION
There is a "," to much in the example configuration from the "Routing Protocols" documentation for OSPF that i removed